### PR TITLE
Added Construction Table

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,3 +88,7 @@ if (proguardEnabled) {
     buildObf.dependsOn build
     buildObf.dependsOn installDist
 }
+
+run {
+    args += ["--debugMode", "--skipIntro"]
+}

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,3 @@ if (proguardEnabled) {
     buildObf.dependsOn build
     buildObf.dependsOn installDist
 }
-
-run {
-    args += ["--debugMode", "--skipIntro"]
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include ":API"
-project(":API").projectDir = file("../API")
+project(":API").projectDir = file("../RockBottomAPI")
 
 gradle.ext.proguardDir = '../proguard/lib'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include ":API"
-project(":API").projectDir = file("../RockBottomAPI")
+project(":API").projectDir = file("../API")
 
 gradle.ext.proguardDir = '../proguard/lib'
 

--- a/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
+++ b/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
@@ -56,6 +56,7 @@ public final class ContentRegistry {
         new TileGrassTorch().register();
         new TileCopper().register();
         new TileSimpleFurnace().register();
+        new TileConstructionTable().register();
         new TileCaveMushroom().register();
         new TileStardrop().register();
         new TileLamp(ResourceName.intern("lamp_iron")).register();
@@ -68,6 +69,11 @@ public final class ContentRegistry {
         new ItemTool(ResourceName.intern("brittle_axe"), 1.25F, 50, ToolProperty.AXE, 1).register();
         new ItemTool(ResourceName.intern("brittle_shovel"), 1.25F, 50, ToolProperty.SHOVEL, 1).register();
         new ItemSword(ResourceName.intern("brittle_sword"), 50, 4, 10, 1.5D, 0.25D).register();
+        new ItemConstructionTool(ResourceName.intern("wrench")).register();
+        new ItemConstructionTool(ResourceName.intern("saw")).register();
+        new ItemConstructionTool(ResourceName.intern("hammer")).register();
+        new ItemConstructionTool(ResourceName.intern("mallet")).register();
+        new ItemConstructionTool(ResourceName.intern("chisel")).register();
         new ItemFirework().register();
         new ItemStartNote().register();
         new ItemBasic(ResourceName.intern("plant_fiber")).register();

--- a/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
+++ b/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
@@ -69,11 +69,11 @@ public final class ContentRegistry {
         new ItemTool(ResourceName.intern("brittle_axe"), 1.25F, 50, ToolProperty.AXE, 1).register();
         new ItemTool(ResourceName.intern("brittle_shovel"), 1.25F, 50, ToolProperty.SHOVEL, 1).register();
         new ItemSword(ResourceName.intern("brittle_sword"), 50, 4, 10, 1.5D, 0.25D).register();
-        new ItemConstructionTool(ResourceName.intern("wrench")).register();
-        new ItemConstructionTool(ResourceName.intern("saw")).register();
-        new ItemConstructionTool(ResourceName.intern("hammer")).register();
-        new ItemConstructionTool(ResourceName.intern("mallet")).register();
-        new ItemConstructionTool(ResourceName.intern("chisel")).register();
+        new ItemConstructionTool(ResourceName.intern("wrench"), 100).register();
+        new ItemConstructionTool(ResourceName.intern("saw"), 100).register();
+        new ItemConstructionTool(ResourceName.intern("hammer"), 100).register();
+        new ItemConstructionTool(ResourceName.intern("mallet"), 100).register();
+        new ItemConstructionTool(ResourceName.intern("chisel"), 100).register();
         new ItemFirework().register();
         new ItemStartNote().register();
         new ItemBasic(ResourceName.intern("plant_fiber")).register();

--- a/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
+++ b/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
@@ -13,7 +13,8 @@ import de.ellpeck.rockbottom.api.tile.TileBasic;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 import de.ellpeck.rockbottom.api.world.gen.biome.level.BiomeLevel;
 import de.ellpeck.rockbottom.api.world.gen.biome.level.BiomeLevelBasic;
-import de.ellpeck.rockbottom.construction.category.CategoryConstruction;
+import de.ellpeck.rockbottom.construction.category.CategoryConstructionTable;
+import de.ellpeck.rockbottom.construction.category.CategoryManualConstruction;
 import de.ellpeck.rockbottom.construction.category.CategoryMortar;
 import de.ellpeck.rockbottom.construction.category.CategorySmelting;
 import de.ellpeck.rockbottom.item.*;
@@ -142,7 +143,8 @@ public final class ContentRegistry {
 
         EntitySlime.SPAWN_BEHAVIOR.register();
 
-        CategoryConstruction.INSTANCE.register();
+        CategoryManualConstruction.INSTANCE.register();
+        new CategoryConstructionTable().register();
         new CategoryMortar().register();
         new CategorySmelting().register();
     }

--- a/src/main/java/de/ellpeck/rockbottom/apiimpl/InternalHooks.java
+++ b/src/main/java/de/ellpeck/rockbottom/apiimpl/InternalHooks.java
@@ -6,6 +6,7 @@ import de.ellpeck.rockbottom.api.assets.IAssetManager;
 import de.ellpeck.rockbottom.api.assets.font.FontProp;
 import de.ellpeck.rockbottom.api.assets.font.FormattingCode;
 import de.ellpeck.rockbottom.api.assets.font.IFont;
+import de.ellpeck.rockbottom.api.construction.ConstructionTool;
 import de.ellpeck.rockbottom.api.construction.compendium.construction.ConstructionRecipe;
 import de.ellpeck.rockbottom.api.data.set.DataSet;
 import de.ellpeck.rockbottom.api.data.settings.Settings;
@@ -52,6 +53,7 @@ import de.ellpeck.rockbottom.net.packet.toserver.PacketShiftClick;
 import de.ellpeck.rockbottom.world.entity.EntityItem;
 import de.ellpeck.rockbottom.world.entity.player.InteractionManager;
 import de.ellpeck.rockbottom.world.entity.player.statistics.StatisticList;
+import de.ellpeck.rockbottom.world.tile.entity.TileEntityConstructionTable;
 import org.lwjgl.glfw.GLFW;
 
 import java.awt.*;
@@ -532,6 +534,14 @@ public class InternalHooks implements IInternalHooks {
                     }
                 }
             }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean useConstructionTableTool(TileEntity constructionTable, ConstructionTool tool, boolean simulate) {
+        if (constructionTable instanceof TileEntityConstructionTable) {
+            return ((TileEntityConstructionTable)constructionTable).damageTool(tool, simulate);
         }
         return false;
     }
@@ -1242,12 +1252,12 @@ public class InternalHooks implements IInternalHooks {
     }
 
     @Override
-    public void defaultConstruct(AbstractEntityPlayer player, ConstructionRecipe recipe) {
+    public void defaultConstruct(AbstractEntityPlayer player, ConstructionRecipe recipe, TileEntity machine) {
         if (RockBottomAPI.getNet().isClient()) {
-            RockBottomAPI.getNet().sendToServer(new PacketManualConstruction(player.getUniqueId(), Registries.MANUAL_CONSTRUCTION_RECIPES.getId(recipe), 1));
+            RockBottomAPI.getNet().sendToServer(new PacketManualConstruction(player.getUniqueId(), Registries.MANUAL_CONSTRUCTION_RECIPES.getId(recipe), machine, 1));
         } else {
             if (recipe.isKnown(player)) {
-                recipe.playerConstruct(player, 1);
+                recipe.playerConstruct(player, machine,1);
             }
         }
     }

--- a/src/main/java/de/ellpeck/rockbottom/construction/ConstructionRegistry.java
+++ b/src/main/java/de/ellpeck/rockbottom/construction/ConstructionRegistry.java
@@ -12,7 +12,6 @@ public final class ConstructionRegistry {
     public static final List<ConstructionRecipe> BRITTLE_TOOLS = new ArrayList<>();
     public static final List<ConstructionRecipe> STONE_TOOLS = new ArrayList<>();
     public static final List<ConstructionRecipe> COPPER_TOOLS = new ArrayList<>();
-    public static final List<ConstructionRecipe> CONSTRUCTION_TOOLS = new ArrayList<>();
     public static ConstructionRecipe ladder;
     public static ConstructionRecipe chest;
     public static ConstructionRecipe grassTorch;
@@ -21,6 +20,7 @@ public final class ConstructionRegistry {
     public static ConstructionRecipe mortar;
     public static ConstructionRecipe pestle;
     public static ConstructionRecipe simpleHoe;
+    public static ConstructionRecipe constructionTable;
 
     public static void postInit() {
         BRITTLE_TOOLS.add(getRecipe(GameContent.ITEM_BRITTLE_PICKAXE));
@@ -52,6 +52,7 @@ public final class ConstructionRegistry {
         mortar = getRecipe(GameContent.TILE_MORTAR.getItem());
         pestle = getRecipe(GameContent.ITEM_PESTLE);
         simpleHoe = getRecipe(GameContent.ITEM_SIMPLE_HOE);
+        constructionTable = getRecipe(GameContent.TILE_CONSTRUCTION_TABLE.getItem());
     }
 
     private static ConstructionRecipe getRecipe(Item item) {

--- a/src/main/java/de/ellpeck/rockbottom/construction/ConstructionRegistry.java
+++ b/src/main/java/de/ellpeck/rockbottom/construction/ConstructionRegistry.java
@@ -12,6 +12,7 @@ public final class ConstructionRegistry {
     public static final List<ConstructionRecipe> BRITTLE_TOOLS = new ArrayList<>();
     public static final List<ConstructionRecipe> STONE_TOOLS = new ArrayList<>();
     public static final List<ConstructionRecipe> COPPER_TOOLS = new ArrayList<>();
+    public static final List<ConstructionRecipe> CONSTRUCTION_TOOLS = new ArrayList<>();
     public static ConstructionRecipe ladder;
     public static ConstructionRecipe chest;
     public static ConstructionRecipe grassTorch;
@@ -31,11 +32,17 @@ public final class ConstructionRegistry {
         STONE_TOOLS.add(getRecipe(GameContent.ITEM_STONE_AXE));
         STONE_TOOLS.add(getRecipe(GameContent.ITEM_STONE_SHOVEL));
         STONE_TOOLS.add(getRecipe(GameContent.ITEM_STONE_SWORD));
+        STONE_TOOLS.add(getRecipe(GameContent.ITEM_WRENCH));
+        STONE_TOOLS.add(getRecipe(GameContent.ITEM_SAW));
+        STONE_TOOLS.add(getRecipe(GameContent.ITEM_HAMMER));
+        STONE_TOOLS.add(getRecipe(GameContent.ITEM_MALLET));
+        STONE_TOOLS.add(getRecipe(GameContent.ITEM_CHISEL));
 
         COPPER_TOOLS.add(getRecipe(GameContent.ITEM_COPPER_PICKAXE));
         COPPER_TOOLS.add(getRecipe(GameContent.ITEM_COPPER_AXE));
         COPPER_TOOLS.add(getRecipe(GameContent.ITEM_COPPER_SHOVEL));
         COPPER_TOOLS.add(getRecipe(GameContent.ITEM_COPPER_SWORD));
+
 
         ladder = getRecipe(GameContent.TILE_LADDER.getItem());
         chest = getRecipe(GameContent.TILE_CHEST.getItem());

--- a/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryConstruction.java
+++ b/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryConstruction.java
@@ -20,7 +20,7 @@ public class CategoryConstruction extends CompendiumCategory {
 
     @Override
     public ResourceName getIcon(IGameInstance game, IAssetManager assetManager, IRenderer g) {
-        return this.getName().addPrefix("gui.construction.");
+        return this.getName().addPrefix("gui.compendium.");
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryConstructionTable.java
@@ -1,0 +1,35 @@
+package de.ellpeck.rockbottom.construction.category;
+
+import de.ellpeck.rockbottom.api.IGameInstance;
+import de.ellpeck.rockbottom.api.IRenderer;
+import de.ellpeck.rockbottom.api.Registries;
+import de.ellpeck.rockbottom.api.assets.IAssetManager;
+import de.ellpeck.rockbottom.api.construction.compendium.CompendiumCategory;
+import de.ellpeck.rockbottom.api.construction.compendium.ICompendiumRecipe;
+import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.construction.ConstructionRegistry;
+
+import java.util.Set;
+
+public class CategoryConstructionTable extends CompendiumCategory {
+
+    public CategoryConstructionTable() {
+        super(ResourceName.intern("construction_table"));
+    }
+
+    @Override
+    public ResourceName getIcon(IGameInstance game, IAssetManager assetManager, IRenderer g) {
+        return this.getName().addPrefix("gui.compendium.");
+    }
+
+    @Override
+    public Set<? extends ICompendiumRecipe> getRecipes() {
+        return Registries.CONSTRUCTION_TABLE_RECIPES.values();
+    }
+
+    @Override
+    public boolean shouldDisplay(AbstractEntityPlayer player) {
+        return ConstructionRegistry.constructionTable == null || ConstructionRegistry.constructionTable.isKnown(player);
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryManualConstruction.java
+++ b/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryManualConstruction.java
@@ -10,12 +10,12 @@ import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 
 import java.util.Set;
 
-public class CategoryConstruction extends CompendiumCategory {
+public class CategoryManualConstruction extends CompendiumCategory {
 
-    public static final CategoryConstruction INSTANCE = new CategoryConstruction();
+    public static final CategoryManualConstruction INSTANCE = new CategoryManualConstruction();
 
-    public CategoryConstruction() {
-        super(ResourceName.intern("construction"));
+    public CategoryManualConstruction() {
+        super(ResourceName.intern("manual_construction"));
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryMortar.java
+++ b/src/main/java/de/ellpeck/rockbottom/construction/category/CategoryMortar.java
@@ -20,7 +20,7 @@ public class CategoryMortar extends CompendiumCategory {
 
     @Override
     public ResourceName getIcon(IGameInstance game, IAssetManager assetManager, IRenderer g) {
-        return this.getName().addPrefix("gui.construction.");
+        return this.getName().addPrefix("gui.compendium.");
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/construction/category/CategorySmelting.java
+++ b/src/main/java/de/ellpeck/rockbottom/construction/category/CategorySmelting.java
@@ -24,12 +24,12 @@ public class CategorySmelting extends CompendiumCategory {
 
     @Override
     public ResourceName getIcon(IGameInstance game, IAssetManager assetManager, IRenderer g) {
-        return this.getName().addPrefix("gui.construction.");
+        return this.getName().addPrefix("gui.compendium.");
     }
 
     @Override
     public ResourceName getBackgroundPicture(Gui gui, IAssetManager manager) {
-        return ResourceName.intern("gui.construction.page_recipes_smelting");
+        return ResourceName.intern("gui.compendium.page_recipes_smelting");
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/content/RecipeLoader.java
+++ b/src/main/java/de/ellpeck/rockbottom/content/RecipeLoader.java
@@ -54,6 +54,12 @@ public class RecipeLoader implements IContentLoader<ConstructionRecipe> {
                 List<IUseInfo> inputList = new ArrayList<>();
                 List<ItemInstance> outputList = new ArrayList<>();
 
+                Item tool = null;
+
+                if (object.has("tool")) {
+                    tool = Registries.ITEM_REGISTRY.get(new ResourceName(object.get("tool").getAsString()));
+                }
+
                 JsonArray outputs = object.get("outputs").getAsJsonArray();
                 for (JsonElement output : outputs) {
                     JsonObject out = output.getAsJsonObject();
@@ -81,9 +87,13 @@ public class RecipeLoader implements IContentLoader<ConstructionRecipe> {
                 }
 
                 if ("manual".equals(type)) {
-                    new ConstructionRecipe(resourceName, inputList, outputList, skill).registerManual();
+                    new ConstructionRecipe(resourceName, null, inputList, outputList, skill).registerManual();
                 } else if ("manual_knowledge".equals(type)) {
-                    new KnowledgeConstructionRecipe(resourceName, inputList, outputList, skill).registerManual();
+                    new KnowledgeConstructionRecipe(resourceName, null, inputList, outputList, skill).registerManual();
+                } else if ("construction_table".equals(type)) {
+                    new ConstructionRecipe(resourceName, tool, inputList, outputList, skill).registerConstructionTable();
+                } else if ("construction_table_knowledge".equals(type)) {
+                    new KnowledgeConstructionRecipe(resourceName, tool, inputList, outputList, skill).registerConstructionTable();
                 } else {
                     throw new IllegalArgumentException("Invalid recipe type " + type + " for recipe " + resourceName);
                 }

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
@@ -38,9 +38,9 @@ public class GuiCompendium extends GuiContainer {
 
     public static final int PAGE_WIDTH = 72;
     public static final int PAGE_HEIGHT = 94;
-    private static final ResourceName LEFT_PAGE = ResourceName.intern("gui.construction.page_items");
-    private static final ResourceName SEARCH_ICON = ResourceName.intern("gui.construction.search_bar");
-    private static final ResourceName SEARCH_BAR = ResourceName.intern("gui.construction.search_bar_extended");
+    private static final ResourceName LEFT_PAGE = ResourceName.intern("gui.compendium.page_items");
+    private static final ResourceName SEARCH_ICON = ResourceName.intern("gui.compendium.search_bar");
+    private static final ResourceName SEARCH_BAR = ResourceName.intern("gui.compendium.search_bar_extended");
     private final List<ComponentPolaroid> polaroids = new ArrayList<>();
     private final List<ComponentIngredient> ingredients = new ArrayList<>();
     private final List<ComponentCompendiumCategory> categories = new ArrayList<>();
@@ -67,14 +67,14 @@ public class GuiCompendium extends GuiContainer {
     public void init(IGameInstance game) {
         super.init(game);
 
-        this.menu = new ComponentMenu(this, -12, 2, 12, PAGE_HEIGHT - 4, 3, 4, 11, 0, new BoundBox(0, 0, PAGE_WIDTH, PAGE_HEIGHT).add(this.x, this.y), ResourceName.intern("gui.construction.scroll_bar"));
+        this.menu = new ComponentMenu(this, -12, 2, 12, PAGE_HEIGHT - 4, 3, 4, 11, 0, new BoundBox(0, 0, PAGE_WIDTH, PAGE_HEIGHT).add(this.x, this.y), ResourceName.intern("gui.compendium.scroll_bar"));
         this.components.add(this.menu);
 
         this.components.add(new ComponentFancyButton(this, 5 - 16, GuiCompendium.PAGE_HEIGHT + 5, 14, 14, () -> {
             this.keepContainerOpen = true;
             game.getGuiManager().openGui(new GuiInventory(this.player));
             return true;
-        }, ResourceName.intern("gui.construction.book_open"), game.getAssetManager().localize(ResourceName.intern("button.close_compendium"))));
+        }, ResourceName.intern("gui.compendium.book_open"), game.getAssetManager().localize(ResourceName.intern("button.close_compendium"))));
 
         this.searchBar = new ComponentInputField(this, 145, 80, 70, 12, false, false, false, 64, false, strg -> {
             if (!strg.equals(this.searchText)) {
@@ -98,14 +98,14 @@ public class GuiCompendium extends GuiContainer {
             categoryOffset--;
             this.sortCategories();
             return true;
-        }, ResourceName.intern("gui.construction.arrow_up"));
+        }, ResourceName.intern("gui.compendium.arrow_up"));
         this.components.add(this.categoryUp.setHasBackground(false));
 
         this.categoryDown = new ComponentFancyButton(this, this.width + 17, 1 + 14 * 5 - 6, 6, 6, () -> {
             categoryOffset++;
             this.sortCategories();
             return true;
-        }, ResourceName.intern("gui.construction.arrow_down"));
+        }, ResourceName.intern("gui.compendium.arrow_down"));
         this.components.add(this.categoryDown.setHasBackground(false));
 
         this.sortCategories();

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
@@ -139,7 +139,7 @@ public class GuiCompendium extends GuiContainer {
             if (recipe.isKnown(this.player)) {
                 if (this.searchText.isEmpty() || this.matchesSearch(recipe.getOutputs())) {
                     IInventory inv = this.player.getInv();
-                    ComponentPolaroid polaroid = recipe.getPolaroidButton(this, this.player, recipe.canConstruct(inv, inv));
+                    ComponentPolaroid polaroid = recipe.getPolaroidButton(this, this.player, recipe.canConstruct(inv, inv), false);
 
                     polaroid.isSelected = this.selectedRecipe == recipe;
                     if (polaroid.isSelected) {
@@ -165,7 +165,7 @@ public class GuiCompendium extends GuiContainer {
         this.menu.organize();
 
         if (this.selectedRecipe != null) {
-            this.stockIngredients(this.selectedRecipe.getIngredientButtons(this, this.player));
+            this.stockIngredients(this.selectedRecipe.getIngredientButtons(this, this.player, false));
         } else {
             this.stockIngredients(Collections.emptyList());
         }
@@ -287,7 +287,7 @@ public class GuiCompendium extends GuiContainer {
                             polaroid.isSelected = true;
 
                             this.initConstructButton(polaroid.recipe);
-                            this.stockIngredients(polaroid.recipe.getIngredientButtons(this, this.player));
+                            this.stockIngredients(polaroid.recipe.getIngredientButtons(this, this.player, false));
                         }
                         did = true;
                     } else {

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
@@ -22,7 +22,7 @@ import de.ellpeck.rockbottom.api.util.BoundBox;
 import de.ellpeck.rockbottom.api.util.Colors;
 import de.ellpeck.rockbottom.api.util.Pos2;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
-import de.ellpeck.rockbottom.construction.category.CategoryConstruction;
+import de.ellpeck.rockbottom.construction.category.CategoryManualConstruction;
 import de.ellpeck.rockbottom.gui.component.ComponentCompendiumCategory;
 
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import java.util.function.BiConsumer;
 
 public class GuiCompendium extends GuiContainer {
 
-    public static CompendiumCategory currentCategory = CategoryConstruction.INSTANCE;
+    public static CompendiumCategory currentCategory = CategoryManualConstruction.INSTANCE;
     private static int categoryOffset;
 
     public static final int PAGE_WIDTH = 72;

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiCompendium.java
@@ -218,7 +218,7 @@ public class GuiCompendium extends GuiContainer {
 
         if (recipe != null) {
             IInventory inv = this.player.getInv();
-            this.construct = recipe.getConstructButton(this, this.player, this.selectedRecipe.canConstruct(inv, inv));
+            this.construct = recipe.getConstructButton(this, this.player, null, this.selectedRecipe.canConstruct(inv, inv));
             this.components.add(this.construct);
         }
     }

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
@@ -1,0 +1,57 @@
+package de.ellpeck.rockbottom.gui;
+
+import de.ellpeck.rockbottom.api.IGameInstance;
+import de.ellpeck.rockbottom.api.IRenderer;
+import de.ellpeck.rockbottom.api.assets.IAssetManager;
+import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
+import de.ellpeck.rockbottom.api.gui.GuiContainer;
+import de.ellpeck.rockbottom.api.gui.component.ComponentMenu;
+import de.ellpeck.rockbottom.api.gui.component.construction.ComponentPolaroid;
+import de.ellpeck.rockbottom.api.util.BoundBox;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.world.tile.entity.TileEntityConstructionTable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GuiConstructionTable extends GuiContainer {
+
+    private static final ResourceName background = ResourceName.intern("gui.construction_table.background");
+    private static final int PAGE_HEIGHT = 94;
+    private static final int MENU_WIDTH = 22 + 4;
+
+    private final TileEntityConstructionTable tile;
+    private ComponentMenu menu;
+    private final List<ComponentPolaroid> polaroids = new ArrayList<>();
+
+    public GuiConstructionTable(AbstractEntityPlayer player, TileEntityConstructionTable tile) {
+        super(player, 135, 169);
+        this.tile = tile;
+
+        int playerSlots = player.getInv().getSlotAmount();
+
+        ShiftClickBehavior input = new ShiftClickBehavior(0, playerSlots - 1, playerSlots, playerSlots - 1 + tile.getTileInventory().getSlotAmount());
+        this.shiftClickBehaviors.add(input);
+        this.shiftClickBehaviors.add(input.reversed());
+    }
+
+    @Override
+    public final void render(IGameInstance game, IAssetManager assetManager, IRenderer renderer) {
+        assetManager.getTexture(background).draw((float) this.x + 7, (float) this.y, 120.0F, 94.0F);
+
+        super.render(game, assetManager, renderer);
+    }
+
+    @Override
+    public void init(IGameInstance game) {
+        super.init(game);
+
+        this.menu = new ComponentMenu(this, 7, 1, 6, PAGE_HEIGHT - 2, 1, 4, 4, 0, new BoundBox(7, 0, MENU_WIDTH, PAGE_HEIGHT).add(this.x, this.y), ResourceName.intern("gui.construction_table.scroll_bar"));
+        this.components.add(this.menu);
+    }
+
+    @Override
+    public ResourceName getName() {
+        return ResourceName.intern("construction_table");
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
@@ -4,6 +4,7 @@ import de.ellpeck.rockbottom.api.IGameInstance;
 import de.ellpeck.rockbottom.api.IRenderer;
 import de.ellpeck.rockbottom.api.Registries;
 import de.ellpeck.rockbottom.api.assets.IAssetManager;
+import de.ellpeck.rockbottom.api.construction.ConstructionTool;
 import de.ellpeck.rockbottom.api.construction.compendium.ICompendiumRecipe;
 import de.ellpeck.rockbottom.api.construction.compendium.construction.ConstructionRecipe;
 import de.ellpeck.rockbottom.api.data.settings.Settings;
@@ -109,7 +110,7 @@ public class GuiConstructionTable extends GuiContainer {
 
         if (recipe != null) {
             IInventory inv = this.player.getInv();
-            this.construct = recipe.getConstructButton(this, this.player, this.selectedRecipe.canConstruct(inv, inv));
+            this.construct = recipe.getConstructButton(this, this.player, tile, this.selectedRecipe.canConstruct(inv, inv));
             this.construct.setPos(56, 17);
             this.components.add(this.construct);
         }
@@ -138,7 +139,7 @@ public class GuiConstructionTable extends GuiContainer {
 
         boolean containsSelected = false;
         for (ConstructionRecipe recipe : Registries.CONSTRUCTION_TABLE_RECIPES.values()) {
-            if (tile.containsTool(recipe.getTool())) {
+            if (recipe.canUseTools(tile)) {
                 if (recipe.isKnown(this.player)) {
                     IInventory inv = this.player.getInv();
                     ComponentPolaroid polaroid = recipe.getPolaroidButton(this, this.player, recipe.canConstruct(inv, inv), true);

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
@@ -6,6 +6,7 @@ import de.ellpeck.rockbottom.api.assets.IAssetManager;
 import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
 import de.ellpeck.rockbottom.api.gui.GuiContainer;
 import de.ellpeck.rockbottom.api.gui.component.ComponentMenu;
+import de.ellpeck.rockbottom.api.gui.component.MenuComponent;
 import de.ellpeck.rockbottom.api.gui.component.construction.ComponentPolaroid;
 import de.ellpeck.rockbottom.api.util.BoundBox;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
@@ -48,6 +49,12 @@ public class GuiConstructionTable extends GuiContainer {
 
         this.menu = new ComponentMenu(this, 7, 1, 6, PAGE_HEIGHT - 2, 1, 4, 4, 0, new BoundBox(7, 0, MENU_WIDTH, PAGE_HEIGHT).add(this.x, this.y), ResourceName.intern("gui.construction_table.scroll_bar"));
         this.components.add(this.menu);
+
+        organise();
+    }
+
+    private void organise() {
+        this.menu.clear();
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
@@ -2,18 +2,29 @@ package de.ellpeck.rockbottom.gui;
 
 import de.ellpeck.rockbottom.api.IGameInstance;
 import de.ellpeck.rockbottom.api.IRenderer;
+import de.ellpeck.rockbottom.api.Registries;
 import de.ellpeck.rockbottom.api.assets.IAssetManager;
+import de.ellpeck.rockbottom.api.construction.compendium.ICompendiumRecipe;
+import de.ellpeck.rockbottom.api.construction.compendium.construction.ConstructionRecipe;
+import de.ellpeck.rockbottom.api.data.settings.Settings;
 import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
 import de.ellpeck.rockbottom.api.gui.GuiContainer;
 import de.ellpeck.rockbottom.api.gui.component.ComponentMenu;
 import de.ellpeck.rockbottom.api.gui.component.MenuComponent;
+import de.ellpeck.rockbottom.api.gui.component.construction.ComponentConstruct;
+import de.ellpeck.rockbottom.api.gui.component.construction.ComponentIngredient;
 import de.ellpeck.rockbottom.api.gui.component.construction.ComponentPolaroid;
+import de.ellpeck.rockbottom.api.inventory.IInventory;
+import de.ellpeck.rockbottom.api.item.ItemInstance;
 import de.ellpeck.rockbottom.api.util.BoundBox;
+import de.ellpeck.rockbottom.api.util.Pos2;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 import de.ellpeck.rockbottom.world.tile.entity.TileEntityConstructionTable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 public class GuiConstructionTable extends GuiContainer {
 
@@ -22,8 +33,13 @@ public class GuiConstructionTable extends GuiContainer {
     private static final int MENU_WIDTH = 22 + 4;
 
     private final TileEntityConstructionTable tile;
-    private ComponentMenu menu;
     private final List<ComponentPolaroid> polaroids = new ArrayList<>();
+    private final List<ComponentIngredient> ingredients = new ArrayList<>();
+    private final BiConsumer<IInventory, Integer> invCallback = (inv, slot) -> this.organise();
+
+    private ComponentMenu menu;
+    private ComponentConstruct construct;
+    private ICompendiumRecipe selectedRecipe;
 
     public GuiConstructionTable(AbstractEntityPlayer player, TileEntityConstructionTable tile) {
         super(player, 135, 169);
@@ -37,6 +53,68 @@ public class GuiConstructionTable extends GuiContainer {
     }
 
     @Override
+    public void onOpened(IGameInstance game) {
+        super.onOpened(game);
+        this.player.getInv().addChangeCallback(this.invCallback);
+        this.tile.getTileInventory().addChangeCallback(this.invCallback);
+    }
+
+    @Override
+    public void onClosed(IGameInstance game) {
+        super.onClosed(game);
+        this.player.getInv().removeChangeCallback(this.invCallback);
+        this.tile.getTileInventory().removeChangeCallback(this.invCallback);
+    }
+
+    @Override
+    public boolean onMouseAction(IGameInstance game, int button, float x, float y) {
+        if (!super.onMouseAction(game, button, x, y)) {
+            if (Settings.KEY_GUI_ACTION_1.isKey(button)) {
+                boolean did = false;
+                for (ComponentPolaroid polaroid : this.polaroids) {
+                    if (polaroid.recipe != null && polaroid.isMouseOverPrioritized(game)) {
+                        if (this.selectedRecipe != polaroid.recipe) {
+                            this.selectedRecipe = polaroid.recipe;
+                            polaroid.isSelected = true;
+
+                            this.initConstructButton(polaroid.recipe);
+                            this.stockIngredients(polaroid.recipe.getIngredientButtons(this, this.player));
+                        }
+                        did = true;
+                    } else {
+                        polaroid.isSelected = false;
+                    }
+                }
+
+                if (!did) {
+                    if (this.selectedRecipe != null) {
+                        this.selectedRecipe = null;
+                        this.initConstructButton(null);
+                        this.stockIngredients(Collections.emptyList());
+                    }
+                }
+                return did;
+            }
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private void initConstructButton(ICompendiumRecipe recipe) {
+        if (this.construct != null) {
+            this.components.remove(this.construct);
+            this.construct = null;
+        }
+
+        if (recipe != null) {
+            IInventory inv = this.player.getInv();
+            this.construct = recipe.getConstructButton(this, this.player, this.selectedRecipe.canConstruct(inv, inv));
+            this.components.add(this.construct);
+        }
+    }
+
+    @Override
     public final void render(IGameInstance game, IAssetManager assetManager, IRenderer renderer) {
         assetManager.getTexture(background).draw((float) this.x + 7, (float) this.y, 120.0F, 94.0F);
 
@@ -47,7 +125,7 @@ public class GuiConstructionTable extends GuiContainer {
     public void init(IGameInstance game) {
         super.init(game);
 
-        this.menu = new ComponentMenu(this, 7, 1, 6, PAGE_HEIGHT - 2, 1, 4, 4, 0, new BoundBox(7, 0, MENU_WIDTH, PAGE_HEIGHT).add(this.x, this.y), ResourceName.intern("gui.construction_table.scroll_bar"));
+        this.menu = new ComponentMenu(this, 7, 1, 6, PAGE_HEIGHT - 2, 1, 4, -2, 1, new BoundBox(7, 0, MENU_WIDTH, PAGE_HEIGHT).add(this.x, this.y), ResourceName.intern("gui.construction_table.scroll_bar"));
         this.components.add(this.menu);
 
         organise();
@@ -55,6 +133,65 @@ public class GuiConstructionTable extends GuiContainer {
 
     private void organise() {
         this.menu.clear();
+        this.polaroids.clear();
+
+        boolean containsSelected = false;
+        for (ConstructionRecipe recipe : Registries.CONSTRUCTION_TABLE_RECIPES.values()) {
+            if (tile.containsTool(recipe.getTool())) {
+                if (recipe.isKnown(this.player)) {
+                    IInventory inv = this.player.getInv();
+                    ComponentPolaroid polaroid = recipe.getPolaroidButton(this, this.player, recipe.canConstruct(inv, inv));
+
+                    polaroid.isSelected = this.selectedRecipe == recipe;
+                    if (polaroid.isSelected) {
+                        containsSelected = true;
+                    }
+
+                    this.polaroids.add(polaroid);
+
+                } else {
+                    this.polaroids.add(new ComponentPolaroid(this, null, false));
+                }
+            }
+        }
+        if (!containsSelected) {
+            this.selectedRecipe = null;
+        }
+
+        this.polaroids.sort((p1, p2) -> Integer.compare(Boolean.compare(p1.recipe == null, p2.recipe == null) * 2, Boolean.compare(p1.canConstruct, p2.canConstruct)));
+
+        for (ComponentPolaroid comp : this.polaroids) {
+            this.menu.add(new MenuComponent(18, 20).add(0, 2, comp));
+        }
+
+        this.menu.organize();
+
+        if (this.selectedRecipe != null) {
+            this.stockIngredients(this.selectedRecipe.getIngredientButtons(this, this.player));
+        } else {
+            this.stockIngredients(Collections.emptyList());
+        }
+    }
+
+    private void stockIngredients(List<ComponentIngredient> actualIngredients) {
+        if (!this.ingredients.isEmpty()) {
+            this.components.removeAll(this.ingredients);
+            this.ingredients.clear();
+        }
+
+        this.ingredients.addAll(actualIngredients);
+        while (this.ingredients.size() < 8) {
+            this.ingredients.add(new ComponentIngredient(this, false, Collections.emptyList()));
+        }
+
+        this.components.addAll(this.ingredients);
+
+        int counter = 0;
+        for (ComponentIngredient comp : this.ingredients) {
+            Pos2 pos = new Pos2(40 + (counter % 4) * 16, 51 + (counter / 4) * 19);
+            comp.setPos(pos.getX(), pos.getY());
+            counter++;
+        }
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
@@ -78,7 +78,7 @@ public class GuiConstructionTable extends GuiContainer {
                             polaroid.isSelected = true;
 
                             this.initConstructButton(polaroid.recipe);
-                            this.stockIngredients(polaroid.recipe.getIngredientButtons(this, this.player));
+                            this.stockIngredients(polaroid.recipe.getIngredientButtons(this, this.player, true));
                         }
                         did = true;
                     } else {
@@ -110,6 +110,7 @@ public class GuiConstructionTable extends GuiContainer {
         if (recipe != null) {
             IInventory inv = this.player.getInv();
             this.construct = recipe.getConstructButton(this, this.player, this.selectedRecipe.canConstruct(inv, inv));
+            this.construct.setPos(56, 17);
             this.components.add(this.construct);
         }
     }
@@ -140,7 +141,7 @@ public class GuiConstructionTable extends GuiContainer {
             if (tile.containsTool(recipe.getTool())) {
                 if (recipe.isKnown(this.player)) {
                     IInventory inv = this.player.getInv();
-                    ComponentPolaroid polaroid = recipe.getPolaroidButton(this, this.player, recipe.canConstruct(inv, inv));
+                    ComponentPolaroid polaroid = recipe.getPolaroidButton(this, this.player, recipe.canConstruct(inv, inv), true);
 
                     polaroid.isSelected = this.selectedRecipe == recipe;
                     if (polaroid.isSelected) {
@@ -150,12 +151,13 @@ public class GuiConstructionTable extends GuiContainer {
                     this.polaroids.add(polaroid);
 
                 } else {
-                    this.polaroids.add(new ComponentPolaroid(this, null, false));
+                    this.polaroids.add(new ComponentPolaroid(this, null, false, ComponentPolaroid.CONSTRUCTION_TEX, ComponentPolaroid.CONSTRUCTION_TEX_HIGHLIGHTED, ComponentPolaroid.CONSTRUCTION_TEX_SELECTED));
                 }
             }
         }
         if (!containsSelected) {
             this.selectedRecipe = null;
+            initConstructButton(null);
         }
 
         this.polaroids.sort((p1, p2) -> Integer.compare(Boolean.compare(p1.recipe == null, p2.recipe == null) * 2, Boolean.compare(p1.canConstruct, p2.canConstruct)));
@@ -167,7 +169,7 @@ public class GuiConstructionTable extends GuiContainer {
         this.menu.organize();
 
         if (this.selectedRecipe != null) {
-            this.stockIngredients(this.selectedRecipe.getIngredientButtons(this, this.player));
+            this.stockIngredients(this.selectedRecipe.getIngredientButtons(this, this.player, true));
         } else {
             this.stockIngredients(Collections.emptyList());
         }
@@ -181,7 +183,7 @@ public class GuiConstructionTable extends GuiContainer {
 
         this.ingredients.addAll(actualIngredients);
         while (this.ingredients.size() < 8) {
-            this.ingredients.add(new ComponentIngredient(this, false, Collections.emptyList()));
+            this.ingredients.add(new ComponentIngredient(this, false, Collections.emptyList(), ComponentIngredient.CONSTRUCTION_TEX, ComponentIngredient.CONSTRUCTION_TEX_NONE));
         }
 
         this.components.addAll(this.ingredients);

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiInventory.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiInventory.java
@@ -26,7 +26,7 @@ public class GuiInventory extends GuiContainer {
             this.keepContainerOpen = true;
             game.getGuiManager().openGui(new GuiCompendium(this.player));
             return true;
-        }, ResourceName.intern("gui.construction.book_closed"), game.getAssetManager().localize(ResourceName.intern("button.open_compendium"))));
+        }, ResourceName.intern("gui.compendium.book_closed"), game.getAssetManager().localize(ResourceName.intern("button.open_compendium"))));
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/gui/component/ComponentCompendiumCategory.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/component/ComponentCompendiumCategory.java
@@ -23,7 +23,7 @@ public class ComponentCompendiumCategory extends GuiComponent {
 
     @Override
     public void render(IGameInstance game, IAssetManager manager, IRenderer g, int x, int y) {
-        ResourceName texture = ResourceName.intern("gui.construction." + (this.isActive ? "tab_extended" : "tab"));
+        ResourceName texture = ResourceName.intern("gui.compendium." + (this.isActive ? "tab_extended" : "tab"));
         manager.getTexture(texture).draw(x, y, this.width, this.height);
 
         int theX = this.isActive ? 3 : 1;

--- a/src/main/java/de/ellpeck/rockbottom/gui/container/ContainerConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/container/ContainerConstructionTable.java
@@ -1,0 +1,30 @@
+package de.ellpeck.rockbottom.gui.container;
+
+import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
+import de.ellpeck.rockbottom.api.gui.container.ItemContainer;
+import de.ellpeck.rockbottom.api.gui.container.RestrictedInputSlot;
+import de.ellpeck.rockbottom.api.tile.entity.IFilteredInventory;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.world.tile.entity.TileEntityConstructionTable;
+
+public class ContainerConstructionTable extends ItemContainer {
+
+    public ContainerConstructionTable(AbstractEntityPlayer player, TileEntityConstructionTable tile) {
+        super(player);
+
+        this.addPlayerInventory(player, 0, 99);
+
+        IFilteredInventory inv = tile.getTileInventory();
+        this.addSlot(new RestrictedInputSlot(inv, 0, 109, 2));
+        this.addSlot(new RestrictedInputSlot(inv, 1, 109, 20));
+        this.addSlot(new RestrictedInputSlot(inv, 2, 109, 38));
+        this.addSlot(new RestrictedInputSlot(inv, 3, 109, 56));
+        this.addSlot(new RestrictedInputSlot(inv, 4, 109, 74));
+    }
+
+    @Override
+    public ResourceName getName() {
+        return ResourceName.intern("construction_table");
+    }
+
+}

--- a/src/main/java/de/ellpeck/rockbottom/item/ItemConstructionTool.java
+++ b/src/main/java/de/ellpeck/rockbottom/item/ItemConstructionTool.java
@@ -1,11 +1,36 @@
 package de.ellpeck.rockbottom.item;
 
+import de.ellpeck.rockbottom.api.assets.IAssetManager;
 import de.ellpeck.rockbottom.api.item.ItemBasic;
+import de.ellpeck.rockbottom.api.item.ItemInstance;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 
+import java.util.List;
+
 public class ItemConstructionTool extends ItemBasic {
-    public ItemConstructionTool(ResourceName name) {
+    private final int durability;
+
+    public ItemConstructionTool(ResourceName name, int durability) {
         super(name);
+        this.durability = durability;
         this.maxAmount = 1;
+    }
+
+    @Override
+    public void describeItem(IAssetManager manager, ItemInstance instance, List<String> desc, boolean isAdvanced) {
+        super.describeItem(manager, instance, desc, isAdvanced);
+
+        int highest = this.getHighestPossibleMeta() + 1;
+        desc.add(manager.localize(ResourceName.intern("info.durability"), highest - instance.getMeta(), highest));
+    }
+
+    @Override
+    public boolean useMetaAsDurability() {
+        return true;
+    }
+
+    @Override
+    public int getHighestPossibleMeta() {
+        return this.durability - 1;
     }
 }

--- a/src/main/java/de/ellpeck/rockbottom/item/ItemConstructionTool.java
+++ b/src/main/java/de/ellpeck/rockbottom/item/ItemConstructionTool.java
@@ -1,0 +1,11 @@
+package de.ellpeck.rockbottom.item;
+
+import de.ellpeck.rockbottom.api.item.ItemBasic;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+
+public class ItemConstructionTool extends ItemBasic {
+    public ItemConstructionTool(ResourceName name) {
+        super(name);
+        this.maxAmount = 1;
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/net/packet/toserver/PacketManualConstruction.java
+++ b/src/main/java/de/ellpeck/rockbottom/net/packet/toserver/PacketManualConstruction.java
@@ -5,6 +5,8 @@ import de.ellpeck.rockbottom.api.construction.compendium.construction.Constructi
 import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
 import de.ellpeck.rockbottom.api.net.NetUtil;
 import de.ellpeck.rockbottom.api.net.packet.IPacket;
+import de.ellpeck.rockbottom.api.tile.entity.TileEntity;
+import de.ellpeck.rockbottom.api.util.Pos2;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -17,7 +19,7 @@ public class PacketManualConstruction implements IPacket {
     private ResourceName recipeName;
     private int amount;
 
-    public PacketManualConstruction(UUID playerId, ResourceName recipeName, int amount) {
+    public PacketManualConstruction(UUID playerId, ResourceName recipeName, TileEntity machine, int amount) {
         this.playerId = playerId;
         this.recipeName = recipeName;
         this.amount = amount;
@@ -48,7 +50,8 @@ public class PacketManualConstruction implements IPacket {
             if (player != null) {
                 ConstructionRecipe recipe = ConstructionRecipe.forName(this.recipeName);
                 if (recipe != null && recipe.isKnown(player)) {
-                    recipe.playerConstruct(player, this.amount);
+                    TileEntity machine = null;
+                    recipe.playerConstruct(player, machine, this.amount);
                 }
             }
         }

--- a/src/main/java/de/ellpeck/rockbottom/world/entity/player/knowledge/RecipeInformation.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/entity/player/knowledge/RecipeInformation.java
@@ -30,12 +30,12 @@ public class RecipeInformation extends Information {
 
     @Override
     public Toast announceForget() {
-        return new Toast(ResourceName.intern("gui.construction.book_closed"), new ChatComponentText("Recipe forgotten"), this.getOutputName(), 200);
+        return new Toast(ResourceName.intern("gui.compendium.book_closed"), new ChatComponentText("Recipe forgotten"), this.getOutputName(), 200);
     }
 
     @Override
     public Toast announceTeach() {
-        return new Toast(ResourceName.intern("gui.construction.book_open"), new ChatComponentText("Recipe learned"), this.getOutputName(), 200);
+        return new Toast(ResourceName.intern("gui.compendium.book_open"), new ChatComponentText("Recipe learned"), this.getOutputName(), 200);
     }
 
     private ChatComponent getOutputName() {

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileConstructionTable.java
@@ -1,0 +1,86 @@
+package de.ellpeck.rockbottom.world.tile;
+
+import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
+import de.ellpeck.rockbottom.api.render.tile.ITileRenderer;
+import de.ellpeck.rockbottom.api.render.tile.MultiTileRenderer;
+import de.ellpeck.rockbottom.api.tile.MultiTile;
+import de.ellpeck.rockbottom.api.tile.entity.TileEntity;
+import de.ellpeck.rockbottom.api.util.BoundBox;
+import de.ellpeck.rockbottom.api.util.Pos2;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.api.world.IWorld;
+import de.ellpeck.rockbottom.api.world.layer.TileLayer;
+import de.ellpeck.rockbottom.gui.GuiConstructionTable;
+import de.ellpeck.rockbottom.gui.container.ContainerConstructionTable;
+import de.ellpeck.rockbottom.world.tile.entity.TileEntityConstructionTable;
+
+public class TileConstructionTable extends MultiTile {
+
+    public TileConstructionTable() {
+        super(ResourceName.intern("construction_table"));
+    }
+
+    @Override
+    public boolean onInteractWith(IWorld world, int x, int y, TileLayer layer, double mouseX, double mouseY, AbstractEntityPlayer player) {
+        Pos2 main = this.getMainPos(x, y, world.getState(layer, x, y));
+        TileEntityConstructionTable tile = world.getTileEntity(layer, main.getX(), main.getY(), TileEntityConstructionTable.class);
+        return tile != null && player.openGuiContainer(new GuiConstructionTable(player, tile), new ContainerConstructionTable(player, tile));
+    }
+
+    @Override
+    public boolean canProvideTileEntity() {
+        return true;
+    }
+
+    @Override
+    public TileEntity provideTileEntity(IWorld world, int x, int y, TileLayer layer) {
+        return this.isMainPos(x, y, world.getState(layer, x, y)) ? new TileEntityConstructionTable(world, x, y, layer) : null;
+    }
+
+    @Override
+    public boolean canPlaceInLayer(TileLayer layer) {
+        return layer == TileLayer.MAIN;
+    }
+
+    @Override
+    public boolean isFullTile() {
+        return false;
+    }
+
+    @Override
+    public BoundBox getBoundBox(IWorld world, int x, int y, TileLayer layer) {
+        return null;
+    }
+
+    @Override
+    protected ITileRenderer createRenderer(ResourceName name) {
+        return new MultiTileRenderer<>(name, this);
+    }
+
+    @Override
+    protected boolean[][] makeStructure() {
+        return new boolean[][]{
+                {true, true}
+        };
+    }
+
+    @Override
+    public int getWidth() {
+        return 2;
+    }
+
+    @Override
+    public int getHeight() {
+        return 1;
+    }
+
+    @Override
+    public int getMainX() {
+        return 0;
+    }
+
+    @Override
+    public int getMainY() {
+        return 0;
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileStone.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileStone.java
@@ -26,6 +26,9 @@ public class TileStone extends TileBasic {
                     player.getKnowledge().teachRecipe(recipe, true);
                 }
             }
+            if (ConstructionRegistry.constructionTable != null) {
+                player.getKnowledge().teachRecipe(ConstructionRegistry.constructionTable, true);
+            }
         }
     }
 }

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityChest.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityChest.java
@@ -25,11 +25,6 @@ public class TileEntityChest extends TileEntity {
     }
 
     @Override
-    public boolean doesTick() {
-        return false;
-    }
-
-    @Override
     public void save(DataSet set, boolean forSync) {
         if (!forSync) {
             this.inventory.save(set);

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityConstructionTable.java
@@ -1,0 +1,50 @@
+package de.ellpeck.rockbottom.world.tile.entity;
+
+import de.ellpeck.rockbottom.api.GameContent;
+import de.ellpeck.rockbottom.api.IGameInstance;
+import de.ellpeck.rockbottom.api.data.set.DataSet;
+import de.ellpeck.rockbottom.api.inventory.CombinedInventory;
+import de.ellpeck.rockbottom.api.tile.entity.IFilteredInventory;
+import de.ellpeck.rockbottom.api.tile.entity.TileEntity;
+import de.ellpeck.rockbottom.api.tile.entity.TileInventory;
+import de.ellpeck.rockbottom.api.world.IWorld;
+import de.ellpeck.rockbottom.api.world.layer.TileLayer;
+import de.ellpeck.rockbottom.item.ItemConstructionTool;
+
+public class TileEntityConstructionTable extends TileEntity {
+
+    private final TileInventory chiselSlot = new TileInventory(this, inst -> inst != null && inst.getItem() == GameContent.ITEM_CHISEL);
+    private final TileInventory hammerSlot = new TileInventory(this, inst -> inst != null && inst.getItem() == GameContent.ITEM_HAMMER);
+    private final TileInventory sawSlot = new TileInventory(this, inst -> inst != null && inst.getItem() == GameContent.ITEM_SAW);
+    private final TileInventory malletSlot = new TileInventory(this, inst -> inst != null && inst.getItem() == GameContent.ITEM_MALLET);
+    private final TileInventory wrenchSlot = new TileInventory(this, inst -> inst != null && inst.getItem() == GameContent.ITEM_WRENCH);
+    private final CombinedInventory inventory = new CombinedInventory(this.chiselSlot, this.hammerSlot, this.sawSlot, this.malletSlot, this.wrenchSlot);
+
+    public TileEntityConstructionTable(IWorld world, int x, int y, TileLayer layer) {
+        super(world, x, y, layer);
+    }
+
+    @Override
+    public IFilteredInventory getTileInventory() {
+        return this.inventory;
+    }
+
+    @Override
+    public void update(IGameInstance game) {
+        super.update(game);
+    }
+
+    @Override
+    public void save(DataSet set, boolean forSync) {
+        if (!forSync) {
+            this.inventory.save(set);
+        }
+    }
+
+    @Override
+    public void load(DataSet set, boolean forSync) {
+        if (!forSync) {
+            this.inventory.load(set);
+        }
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityConstructionTable.java
@@ -2,9 +2,11 @@ package de.ellpeck.rockbottom.world.tile.entity;
 
 import de.ellpeck.rockbottom.api.GameContent;
 import de.ellpeck.rockbottom.api.IGameInstance;
+import de.ellpeck.rockbottom.api.construction.ConstructionTool;
 import de.ellpeck.rockbottom.api.data.set.DataSet;
 import de.ellpeck.rockbottom.api.inventory.CombinedInventory;
 import de.ellpeck.rockbottom.api.item.Item;
+import de.ellpeck.rockbottom.api.item.ItemInstance;
 import de.ellpeck.rockbottom.api.tile.entity.IFilteredInventory;
 import de.ellpeck.rockbottom.api.tile.entity.TileEntity;
 import de.ellpeck.rockbottom.api.tile.entity.TileInventory;
@@ -35,19 +37,36 @@ public class TileEntityConstructionTable extends TileEntity {
         super.update(game);
     }
 
-    public boolean containsTool(Item tool) {
-        if (tool == GameContent.ITEM_CHISEL) {
-            return chiselSlot.get(0) != null;
-        } else if (tool == GameContent.ITEM_HAMMER) {
-            return hammerSlot.get(0) != null;
-        } else if (tool == GameContent.ITEM_SAW) {
-            return sawSlot.get(0) != null;
-        } else if (tool == GameContent.ITEM_MALLET) {
-            return malletSlot.get(0) != null;
-        } else if (tool == GameContent.ITEM_WRENCH) {
-            return wrenchSlot.get(0) != null;
+    /**
+     * Damages the specified tool in the table if it is found
+     * @param tool Tool to be damaged
+     * @param simulate Should we only check for the existence of the tool?
+     * @return True if the tool exists
+     */
+    public boolean damageTool(ConstructionTool tool, boolean simulate) {
+        ItemInstance toolItem;
+        if (tool != null && (toolItem = getTool(tool.tool)) != null) {
+            if (!simulate) {
+                toolItem.getItem().takeDamage(toolItem, tool.durability);
+            }
+            return true;
         }
-        return tool == null;
+        return tool == null || tool.tool == null;
+    }
+
+    private ItemInstance getTool(Item tool) {
+        if (tool == GameContent.ITEM_CHISEL) {
+            return chiselSlot.get(0);
+        } else if (tool == GameContent.ITEM_HAMMER) {
+            return hammerSlot.get(0);
+        } else if (tool == GameContent.ITEM_SAW) {
+            return sawSlot.get(0);
+        } else if (tool == GameContent.ITEM_MALLET) {
+            return malletSlot.get(0);
+        } else if (tool == GameContent.ITEM_WRENCH) {
+            return wrenchSlot.get(0);
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityConstructionTable.java
@@ -4,6 +4,7 @@ import de.ellpeck.rockbottom.api.GameContent;
 import de.ellpeck.rockbottom.api.IGameInstance;
 import de.ellpeck.rockbottom.api.data.set.DataSet;
 import de.ellpeck.rockbottom.api.inventory.CombinedInventory;
+import de.ellpeck.rockbottom.api.item.Item;
 import de.ellpeck.rockbottom.api.tile.entity.IFilteredInventory;
 import de.ellpeck.rockbottom.api.tile.entity.TileEntity;
 import de.ellpeck.rockbottom.api.tile.entity.TileInventory;
@@ -32,6 +33,21 @@ public class TileEntityConstructionTable extends TileEntity {
     @Override
     public void update(IGameInstance game) {
         super.update(game);
+    }
+
+    public boolean containsTool(Item tool) {
+        if (tool == GameContent.ITEM_CHISEL) {
+            return chiselSlot.get(0) != null;
+        } else if (tool == GameContent.ITEM_HAMMER) {
+            return hammerSlot.get(0) != null;
+        } else if (tool == GameContent.ITEM_SAW) {
+            return sawSlot.get(0) != null;
+        } else if (tool == GameContent.ITEM_MALLET) {
+            return malletSlot.get(0) != null;
+        } else if (tool == GameContent.ITEM_WRENCH) {
+            return wrenchSlot.get(0) != null;
+        }
+        return tool == null;
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityMortar.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntityMortar.java
@@ -55,11 +55,6 @@ public class TileEntityMortar extends TileEntity {
     }
 
     @Override
-    public boolean doesTick() {
-        return false;
-    }
-
-    @Override
     public IFilteredInventory getTileInventory() {
         return this.inventory;
     }

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntitySign.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/entity/TileEntitySign.java
@@ -31,9 +31,4 @@ public class TileEntitySign extends TileEntity {
             this.text[i] = set.getString("text_" + i);
         }
     }
-
-    @Override
-    public boolean doesTick() {
-        return false;
-    }
 }


### PR DESCRIPTION
The construction table can be used to construct recipes with the aid of one or many tools! This pr adds two new recipe types, `construction_table` and `construction_table_knowledge`, similar to `manual` and `manual_knowledge` with the twist that these recipes take a array of tools required to craft them. Construction recipes show up in the compendium, and can be viewed and crafted in the Construction Table GUI once the correct tools are placed in their slots. Below is an example recipe json which uses 5 durability from a saw and 2 durability from a hammer to create a chest.

```json
{
    "type": "construction_table_knowledge",
    "tools": [
        {
            "name": "rockbottom/saw",
            "durability": 5
        },
        {
            "name": "rockbottom/hammer",
            "durability": 2
        }
    ],
    "outputs": [
        {
            "name": "rockbottom/chest"
        }
    ],
    "inputs": [
        {
            "name": "wood_processed",
            "amount": 20
        },
        {
            "name": "wood_raw",
            "amount": 4
        }
    ],
    "skill": 0.015
}
```