### PR TITLE
Easily disable slot rendering & force a specific color

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/apiimpl/Renderer.java
+++ b/src/main/java/de/ellpeck/rockbottom/apiimpl/Renderer.java
@@ -421,9 +421,6 @@ public class Renderer implements IRenderer {
     public void renderSlotInGui(IGameInstance game, IAssetManager manager, ItemInstance slot, float x, float y, float scale, boolean hovered, boolean canPlaceInto, boolean renderBackground, int colorOverride) {
         ITexture texture = manager.getTexture(SLOT_NAME);
         if (renderBackground) {
-            if (colorOverride == -1) {
-                colorOverride = game.getSettings().guiColor;
-            }
             if (!canPlaceInto) {
                 colorOverride = Colors.multiply(colorOverride, 0.5F);
             } else if (!hovered) {

--- a/src/main/java/de/ellpeck/rockbottom/apiimpl/Renderer.java
+++ b/src/main/java/de/ellpeck/rockbottom/apiimpl/Renderer.java
@@ -414,23 +414,27 @@ public class Renderer implements IRenderer {
 
     @Override
     public void renderSlotInGui(IGameInstance game, IAssetManager manager, ItemInstance slot, float x, float y, float scale, boolean hovered, boolean canPlaceInto) {
+        renderSlotInGui(game, manager, slot, x, y, scale, hovered, canPlaceInto, true, -1);
+    }
+
+    @Override
+    public void renderSlotInGui(IGameInstance game, IAssetManager manager, ItemInstance slot, float x, float y, float scale, boolean hovered, boolean canPlaceInto, boolean renderBackground, int colorOverride) {
         ITexture texture = manager.getTexture(SLOT_NAME);
-
-        int color = game.getSettings().guiColor;
-
-        if (!canPlaceInto) {
-            color = Colors.multiply(color, 0.5F);
-        } else if (!hovered) {
-            color = Colors.multiply(color, 0.75F);
+        if (renderBackground) {
+            if (colorOverride == -1) {
+                colorOverride = game.getSettings().guiColor;
+            }
+            if (!canPlaceInto) {
+                colorOverride = Colors.multiply(colorOverride, 0.5F);
+            } else if (!hovered) {
+                colorOverride = Colors.multiply(colorOverride, 0.75F);
+            }
+            texture.draw(x, y, texture.getRenderWidth() * scale, texture.getRenderHeight() * scale, colorOverride);
         }
-
-        texture.draw(x, y, texture.getRenderWidth() * scale, texture.getRenderHeight() * scale, color);
-
         if (slot != null) {
             this.renderItemInGui(game, manager, slot, x + 3F * scale, y + 3F * scale, scale, Colors.WHITE);
         }
     }
-
 
     @Override
     public void renderItemInGui(IGameInstance game, IAssetManager manager, ItemInstance slot, float x, float y, float scale, int color) {

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
@@ -18,6 +18,7 @@ import de.ellpeck.rockbottom.api.gui.component.construction.ComponentPolaroid;
 import de.ellpeck.rockbottom.api.inventory.IInventory;
 import de.ellpeck.rockbottom.api.item.ItemInstance;
 import de.ellpeck.rockbottom.api.util.BoundBox;
+import de.ellpeck.rockbottom.api.util.Colors;
 import de.ellpeck.rockbottom.api.util.Pos2;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 import de.ellpeck.rockbottom.world.tile.entity.TileEntityConstructionTable;
@@ -119,7 +120,10 @@ public class GuiConstructionTable extends GuiContainer {
     @Override
     public final void render(IGameInstance game, IAssetManager assetManager, IRenderer renderer) {
         assetManager.getTexture(background).draw((float) this.x + 7, (float) this.y, 120.0F, 94.0F);
-
+        if (this.selectedRecipe != null) {
+            String strg = this.selectedRecipe.getOutputs().get(0).getDisplayName();
+            assetManager.getFont().drawAutoScaledString(this.x + 72, this.y + 6, strg, 0.25F, 72 - 2, Colors.BLACK, Colors.NO_COLOR, true, false);
+        }
         super.render(game, assetManager, renderer);
     }
 

--- a/src/main/java/de/ellpeck/rockbottom/gui/container/ContainerConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/container/ContainerConstructionTable.java
@@ -4,6 +4,7 @@ import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
 import de.ellpeck.rockbottom.api.gui.container.ItemContainer;
 import de.ellpeck.rockbottom.api.gui.container.RestrictedInputSlot;
 import de.ellpeck.rockbottom.api.tile.entity.IFilteredInventory;
+import de.ellpeck.rockbottom.api.util.Colors;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 import de.ellpeck.rockbottom.world.tile.entity.TileEntityConstructionTable;
 
@@ -15,11 +16,11 @@ public class ContainerConstructionTable extends ItemContainer {
         this.addPlayerInventory(player, 0, 99);
 
         IFilteredInventory inv = tile.getTileInventory();
-        this.addSlot(new RestrictedInputSlot(inv, 0, 109, 2));
-        this.addSlot(new RestrictedInputSlot(inv, 1, 109, 20));
-        this.addSlot(new RestrictedInputSlot(inv, 2, 109, 38));
-        this.addSlot(new RestrictedInputSlot(inv, 3, 109, 56));
-        this.addSlot(new RestrictedInputSlot(inv, 4, 109, 74));
+        this.addSlot(new RestrictedInputSlot(inv, 0, 109, 2).disableSlotBackgroundRender());
+        this.addSlot(new RestrictedInputSlot(inv, 1, 109, 20).disableSlotBackgroundRender());
+        this.addSlot(new RestrictedInputSlot(inv, 2, 109, 38).disableSlotBackgroundRender());
+        this.addSlot(new RestrictedInputSlot(inv, 3, 109, 56).disableSlotBackgroundRender());
+        this.addSlot(new RestrictedInputSlot(inv, 4, 109, 74).disableSlotBackgroundRender());
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileConstructionTable.java
@@ -5,6 +5,7 @@ import de.ellpeck.rockbottom.api.render.tile.ITileRenderer;
 import de.ellpeck.rockbottom.api.render.tile.MultiTileRenderer;
 import de.ellpeck.rockbottom.api.tile.MultiTile;
 import de.ellpeck.rockbottom.api.tile.entity.TileEntity;
+import de.ellpeck.rockbottom.api.tile.state.TileState;
 import de.ellpeck.rockbottom.api.util.BoundBox;
 import de.ellpeck.rockbottom.api.util.Pos2;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
@@ -48,7 +49,7 @@ public class TileConstructionTable extends MultiTile {
     }
 
     @Override
-    public BoundBox getBoundBox(IWorld world, int x, int y, TileLayer layer) {
+    public BoundBox getBoundBox(IWorld world, TileState state, int x, int y, TileLayer layer) {
         return null;
     }
 


### PR DESCRIPTION
This allows you to not render slot backgrounds and change their color without overriding multiple classes (ComponentSlot and ContainerSlot). Adding slots with no background or specific colors is now as easy as this:

```java
// This slot will have no background
this.addSlot(new RestrictedInputSlot(inv, 4, 109, 74).disableSlotBackgroundRender());
// This one will be black no matter what your GUI color is set to
this.addSlot(new RestrictedInputSlot(inv, 2, 109, 74).setSlotColorOverride(0xff000000));
```

Also make sure to review the API pr https://github.com/RockBottomGame/API/pull/24