### PR TITLE
Sticks and Exclusive Recipes

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
+++ b/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
@@ -79,6 +79,7 @@ public final class ContentRegistry {
         new ItemStartNote().register();
         new ItemBasic(ResourceName.intern("plant_fiber")).register();
         new ItemTwig().register();
+        new ItemBasic(ResourceName.intern("stick")).register();
         new ItemTool(ResourceName.intern("stone_pickaxe"), 2.5F, 120, ToolProperty.PICKAXE, 5).register();
         new ItemTool(ResourceName.intern("stone_axe"), 1.5F, 120, ToolProperty.AXE, 5).register();
         new ItemTool(ResourceName.intern("stone_shovel"), 1.5F, 120, ToolProperty.SHOVEL, 5).register();

--- a/src/main/java/de/ellpeck/rockbottom/content/ConstructionRecipeLoader.java
+++ b/src/main/java/de/ellpeck/rockbottom/content/ConstructionRecipeLoader.java
@@ -64,10 +64,10 @@ public class ConstructionRecipeLoader implements IContentLoader<ConstructionReci
                 }
 
                 ConstructionRecipe recipe;
-                if ("manual".equals(type)) {
-                    recipe = new ConstructionRecipe(resourceName, null, inputList, outputList, knowledge, skill).registerManual();
+                if ("manual".equals(type) || "manual_only".equals(type)) {
+                    recipe = new ConstructionRecipe(resourceName, null, inputList, outputList, !"manual_only".equals(type), knowledge, skill).registerManual();
                 } else if ("construction_table".equals(type)) {
-                    recipe = new ConstructionRecipe(resourceName, tools, inputList, outputList, knowledge, skill).registerConstructionTable();
+                    recipe = new ConstructionRecipe(resourceName, tools, inputList, outputList, true, knowledge, skill).registerConstructionTable();
                 } else {
                     throw new IllegalArgumentException("Invalid recipe type " + type + " for recipe " + resourceName);
                 }

--- a/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
+++ b/src/main/java/de/ellpeck/rockbottom/gui/GuiConstructionTable.java
@@ -144,7 +144,7 @@ public class GuiConstructionTable extends GuiContainer {
 
         boolean containsSelected = false;
         for (ConstructionRecipe recipe : Registries.CONSTRUCTION_RECIPES.values()) {
-            if (recipe.canUseTools(tile)) {
+            if (recipe.showInConstructionTable() && recipe.canUseTools(tile)) {
                 if (recipe.isKnown(this.player)) {
                     IInventory inv = this.player.getInv();
                     ComponentPolaroid polaroid = recipe.getPolaroidButton(this, player, recipe.canConstruct(inv, inv), POLAROID_TEX);


### PR DESCRIPTION
You can now have recipes which are exclusively for manual crafting. To demonstrate this, I added a manual wood board recipe which only yields one board, and a second which yields three but requires a saw in the construction table. I also added sticks, which can be constructed with wood boards and a saw and work as a substitute for twigs in recipes.

Also check the [Assets](https://github.com/RockBottomGame/Assets/pull/22) and [API](https://github.com/RockBottomGame/API/pull/35) PR's.