### PR TITLE
Added Cotton, Yarn & a Spinning Wheel

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
+++ b/src/main/java/de/ellpeck/rockbottom/ContentRegistry.java
@@ -56,6 +56,7 @@ public final class ContentRegistry {
         new TileRemainsGoo().register();
         new TileGrassTorch().register();
         new TileCopper().register();
+        new TileSpinningWheel().register();
         new TileSimpleFurnace().register();
         new TileConstructionTable().register();
         new TileCaveMushroom().register();
@@ -64,6 +65,7 @@ public final class ContentRegistry {
         new TileMortar().register();
         new TileTilledSoil().register();
         new TileCorn().register();
+        new TileCotton().register();
         new TileGlass().register();
 
         new ItemTool(ResourceName.intern("brittle_pickaxe"), 1.5F, 50, ToolProperty.PICKAXE, 1).register();
@@ -78,6 +80,7 @@ public final class ContentRegistry {
         new ItemFirework().register();
         new ItemStartNote().register();
         new ItemBasic(ResourceName.intern("plant_fiber")).register();
+        new ItemBasic(ResourceName.intern("yarn")).register();
         new ItemTwig().register();
         new ItemBasic(ResourceName.intern("stick")).register();
         new ItemTool(ResourceName.intern("stone_pickaxe"), 2.5F, 120, ToolProperty.PICKAXE, 5).register();
@@ -128,6 +131,7 @@ public final class ContentRegistry {
         Registries.WORLD_GENERATORS.register(ResourceName.intern("stardrops"), WorldGenStardrops.class);
         Registries.WORLD_GENERATORS.register(ResourceName.intern("lakes"), WorldGenLakes.class);
         Registries.WORLD_GENERATORS.register(ResourceName.intern("corn"), WorldGenCorn.class);
+        Registries.WORLD_GENERATORS.register(ResourceName.intern("cotton"), WorldGenCotton.class);
 
         Registries.INFORMATION_REGISTRY.register(RecipeInformation.REG_NAME, RecipeInformation.class);
 

--- a/src/main/java/de/ellpeck/rockbottom/content/ConstructionRecipeLoader.java
+++ b/src/main/java/de/ellpeck/rockbottom/content/ConstructionRecipeLoader.java
@@ -65,9 +65,9 @@ public class ConstructionRecipeLoader implements IContentLoader<ConstructionReci
 
                 ConstructionRecipe recipe;
                 if ("manual".equals(type) || "manual_only".equals(type)) {
-                    recipe = new ConstructionRecipe(resourceName, null, inputList, outputList, !"manual_only".equals(type), knowledge, skill).registerManual();
+                    recipe = new ConstructionRecipe(resourceName, null, inputList, outputList, "manual_only".equals(type), knowledge, skill).registerManual();
                 } else if ("construction_table".equals(type)) {
-                    recipe = new ConstructionRecipe(resourceName, tools, inputList, outputList, true, knowledge, skill).registerConstructionTable();
+                    recipe = new ConstructionRecipe(resourceName, tools, inputList, outputList, false, knowledge, skill).registerConstructionTable();
                 } else {
                     throw new IllegalArgumentException("Invalid recipe type " + type + " for recipe " + resourceName);
                 }

--- a/src/main/java/de/ellpeck/rockbottom/content/ConstructionRecipeLoader.java
+++ b/src/main/java/de/ellpeck/rockbottom/content/ConstructionRecipeLoader.java
@@ -65,9 +65,9 @@ public class ConstructionRecipeLoader implements IContentLoader<ConstructionReci
 
                 ConstructionRecipe recipe;
                 if ("manual".equals(type) || "manual_only".equals(type)) {
-                    recipe = new ConstructionRecipe(resourceName, null, inputList, outputList, "manual_only".equals(type), knowledge, skill).registerManual();
+                    recipe = new ConstructionRecipe(resourceName, null, inputList, outputList, !"manual_only".equals(type), knowledge, skill).registerManual();
                 } else if ("construction_table".equals(type)) {
-                    recipe = new ConstructionRecipe(resourceName, tools, inputList, outputList, false, knowledge, skill).registerConstructionTable();
+                    recipe = new ConstructionRecipe(resourceName, tools, inputList, outputList, true, knowledge, skill).registerConstructionTable();
                 } else {
                     throw new IllegalArgumentException("Invalid recipe type " + type + " for recipe " + resourceName);
                 }

--- a/src/main/java/de/ellpeck/rockbottom/init/AbstractGame.java
+++ b/src/main/java/de/ellpeck/rockbottom/init/AbstractGame.java
@@ -351,7 +351,7 @@ public abstract class AbstractGame implements IGameInstance {
 
     @Override
     public String[] getAuthors() {
-        return new String[]{"Ellpeck", "wiiv"};
+        return new String[]{"Ellpeck", "wiiv", "raphydaphy", "Quarris", "canitzp"};
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/render/tile/TileCornRenderer.java
+++ b/src/main/java/de/ellpeck/rockbottom/render/tile/TileCornRenderer.java
@@ -32,7 +32,7 @@ public class TileCornRenderer extends DefaultTileRenderer<TileCorn> {
     @Override
     public void renderInForeground(IGameInstance game, IAssetManager manager, IRenderer g, IWorld world, TileCorn tile, TileState state, int x, int y, TileLayer layer, float renderX, float renderY, float scale, int[] light) {
         int top = state.get(StaticTileProps.TOP_HALF) ? 1 : 0;
-        int variant = state.get(StaticTileProps.CORN_GROWTH);
+        int variant = state.get(StaticTileProps.PLANT_GROWTH);
         manager.getTexture(this.textures[top][variant]).draw(renderX, renderY, scale, scale, light);
     }
 }

--- a/src/main/java/de/ellpeck/rockbottom/render/tile/TileCottonRenderer.java
+++ b/src/main/java/de/ellpeck/rockbottom/render/tile/TileCottonRenderer.java
@@ -1,0 +1,51 @@
+package de.ellpeck.rockbottom.render.tile;
+
+
+import de.ellpeck.rockbottom.api.IGameInstance;
+import de.ellpeck.rockbottom.api.IRenderer;
+import de.ellpeck.rockbottom.api.StaticTileProps;
+import de.ellpeck.rockbottom.api.assets.IAssetManager;
+import de.ellpeck.rockbottom.api.render.tile.DefaultTileRenderer;
+import de.ellpeck.rockbottom.api.tile.Tile;
+import de.ellpeck.rockbottom.api.tile.state.TileState;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.api.world.IWorld;
+import de.ellpeck.rockbottom.api.world.layer.TileLayer;
+
+public class TileCottonRenderer extends DefaultTileRenderer {
+    private final ResourceName[][] alive = new ResourceName[2][10];
+    private final ResourceName[][] dead = new ResourceName[2][5];
+
+    public TileCottonRenderer(ResourceName name) {
+        super(name);
+
+        for (int i = 0; i < 10; ++i) {
+            this.alive[0][i] = this.texture.addSuffix("." + i + ".bottom");
+            this.alive[1][i] = this.texture.addSuffix("." + i + ".top");
+
+            if (i < 5) {
+                this.dead[0][i] = this.texture.addSuffix(".dead." + i + ".bottom");
+                this.dead[1][i] = this.texture.addSuffix(".dead." + i + ".top");
+            }
+        }
+
+    }
+
+    @Override
+    public void render(IGameInstance game, IAssetManager manager, IRenderer g, IWorld world, Tile tile, TileState state, int x, int y, TileLayer layer, float renderX, float renderY, float scale, int[] light) {
+
+    }
+
+    @Override
+    public void renderInForeground(IGameInstance game, IAssetManager manager, IRenderer g, IWorld world, Tile tile, TileState state, int x, int y, TileLayer layer, float renderX, float renderY, float scale, int[] light) {
+        boolean top = state.get(StaticTileProps.TOP_HALF);
+        int growth = state.get(StaticTileProps.PLANT_GROWTH);
+
+        if (!state.get(StaticTileProps.ALIVE)) {
+            manager.getTexture(this.dead[top ? 1 : 0][Math.min(growth, 4)]).getPositionalVariation(x, y).draw(renderX, renderY, scale, scale, light);
+        } else {
+            manager.getTexture(this.alive[top ? 1 : 0][growth]).getPositionalVariation(x, y).draw(renderX, renderY, scale, scale, light);
+        }
+
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/render/tile/TileSpinningWheelRenderer.java
+++ b/src/main/java/de/ellpeck/rockbottom/render/tile/TileSpinningWheelRenderer.java
@@ -1,0 +1,34 @@
+package de.ellpeck.rockbottom.render.tile;
+
+
+import de.ellpeck.rockbottom.api.IGameInstance;
+import de.ellpeck.rockbottom.api.IRenderer;
+import de.ellpeck.rockbottom.api.StaticTileProps;
+import de.ellpeck.rockbottom.api.assets.IAssetManager;
+import de.ellpeck.rockbottom.api.render.tile.MultiTileRenderer;
+import de.ellpeck.rockbottom.api.tile.state.TileState;
+import de.ellpeck.rockbottom.api.util.Pos2;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.api.world.IWorld;
+import de.ellpeck.rockbottom.api.world.layer.TileLayer;
+import de.ellpeck.rockbottom.world.tile.TileSpinningWheel;
+
+public class TileSpinningWheelRenderer extends MultiTileRenderer<TileSpinningWheel>
+{
+    public TileSpinningWheelRenderer(ResourceName texture, TileSpinningWheel tile)
+    {
+        super(texture, tile);
+    }
+
+    @Override
+    public void render(IGameInstance game, IAssetManager manager, IRenderer g, IWorld world, TileSpinningWheel tile, TileState state, int x, int y, TileLayer layer, float renderX, float renderY, float scale, int[] light)
+    {
+        Pos2 innerCoord = tile.getInnerCoord(state);
+        Pos2 main = tile.getMainPos(x, y, state);
+        int stage = world.getState(main.getX(), main.getY()).get(StaticTileProps.SPINNING_STAGE);
+
+        ResourceName tex = this.textures.get(innerCoord);
+        manager.getTexture(stage == 0 ? tex : this.texture.addSuffix("." + stage + "." + innerCoord.getX() + "." + innerCoord.getY())).getPositionalVariation(x, y).draw(renderX, renderY, scale, scale, light);
+    }
+
+}

--- a/src/main/java/de/ellpeck/rockbottom/world/gen/feature/WorldGenCorn.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/gen/feature/WorldGenCorn.java
@@ -38,8 +38,8 @@ public class WorldGenCorn implements IWorldGenerator {
                         if (chunk.getStateInner(x + xOff, y).getTile().canReplace(world, chunk.getX() + x + xOff, chunk.getY() + y, TileLayer.MAIN) && chunk.getStateInner(x + xOff, y + 1).getTile().canReplace(world, chunk.getX() + x + xOff, chunk.getY() + y + 1, TileLayer.MAIN)) {
                             chunk.setStateInner(x + xOff, y - 1, GameContent.TILE_SOIL_TILLED.getDefState());
 
-                            chunk.setStateInner(x + xOff, y, GameContent.TILE_CORN.getDefState().prop(StaticTileProps.CORN_GROWTH, 9));
-                            chunk.setStateInner(x + xOff, y + 1, GameContent.TILE_CORN.getDefState().prop(StaticTileProps.TOP_HALF, true).prop(StaticTileProps.CORN_GROWTH, 9));
+                            chunk.setStateInner(x + xOff, y, GameContent.TILE_CORN.getDefState().prop(StaticTileProps.PLANT_GROWTH, 9));
+                            chunk.setStateInner(x + xOff, y + 1, GameContent.TILE_CORN.getDefState().prop(StaticTileProps.TOP_HALF, true).prop(StaticTileProps.PLANT_GROWTH, 9));
                         }
                     }
                 }

--- a/src/main/java/de/ellpeck/rockbottom/world/gen/feature/WorldGenCotton.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/gen/feature/WorldGenCotton.java
@@ -1,0 +1,62 @@
+package de.ellpeck.rockbottom.world.gen.feature;
+
+
+import de.ellpeck.rockbottom.api.GameContent;
+import de.ellpeck.rockbottom.api.StaticTileProps;
+import de.ellpeck.rockbottom.api.tile.state.TileState;
+import de.ellpeck.rockbottom.api.util.Util;
+import de.ellpeck.rockbottom.api.world.IChunk;
+import de.ellpeck.rockbottom.api.world.IWorld;
+import de.ellpeck.rockbottom.api.world.gen.IWorldGenerator;
+import de.ellpeck.rockbottom.api.world.layer.TileLayer;
+
+import java.util.Random;
+
+public class WorldGenCotton implements IWorldGenerator {
+    private final Random lakeRand = new Random();
+    private final Random cottonRand = new Random();
+
+    public WorldGenCotton() {
+    }
+
+    public void initWorld(IWorld var1) {
+        this.cottonRand.setSeed(Util.scrambleSeed(93719028, var1.getSeed()));
+    }
+
+    public boolean shouldGenerate(IWorld world, IChunk chunk) {
+        return true;
+    }
+
+    public void generate(IWorld world, IChunk chunk) {
+        this.lakeRand.setSeed(Util.scrambleSeed(chunk.getGridX(), chunk.getGridY(), world.getSeed()));
+        if (lakeRand.nextFloat() <= chunk.getMostProminentBiome().getLakeChance(world, chunk)) {
+            for (int x = 0; x < 31; x++) {
+                int height = chunk.getHeightInner(TileLayer.LIQUIDS, x);
+                if (height > 0 && height < 31) {
+                    TileState water = chunk.getStateInner(TileLayer.LIQUIDS, x, height - 1);
+                    height -= 1;
+                    x += 1;
+                    int left = x - 2;
+                    if (water.getTile() == GameContent.TILE_WATER && chunk.getStateInner(x, height).getTile().canKeepPlants(world, chunk.getX() + x, chunk.getY() + height, TileLayer.MAIN) && chunk.getStateInner(TileLayer.LIQUIDS, x, height).getTile().isAir() && chunk.getStateInner(x, height + 1).getTile().canReplace(world, chunk.getX() + x, chunk.getY() + height + 1, TileLayer.MAIN) && chunk.getStateInner(x, height + 2).getTile().canReplace(world, chunk.getX() + x, chunk.getY() + height + 2, TileLayer.MAIN)) {
+                        placeCotton(chunk, x, height);
+                    } else if (water.getTile() == GameContent.TILE_WATER && chunk.getStateInner(left, height).getTile().canKeepPlants(world, chunk.getX() + left, chunk.getY() + height, TileLayer.MAIN) && chunk.getStateInner(TileLayer.LIQUIDS, left, height).getTile().isAir() && chunk.getStateInner(left, height + 1).getTile().canReplace(world, chunk.getX() + left, chunk.getY() + height + 1, TileLayer.MAIN) && chunk.getStateInner(left, height + 2).getTile().canReplace(world, chunk.getX() + left, chunk.getY() + height + 2, TileLayer.MAIN) && cottonRand.nextBoolean()) {
+                        placeCotton(chunk, left, height);
+                        return;
+                    }
+
+                }
+            }
+        }
+
+    }
+
+    private void placeCotton(IChunk chunk, int x, int y) {
+        chunk.setStateInner(x, y, GameContent.TILE_SOIL_TILLED.getDefState());
+        chunk.setStateInner(x, y + 1, GameContent.TILE_COTTON.getDefState().prop(StaticTileProps.PLANT_GROWTH, 9).prop(StaticTileProps.ALIVE, true));
+        chunk.setStateInner(x, y + 2, GameContent.TILE_COTTON.getDefState().prop(StaticTileProps.TOP_HALF, true).prop(StaticTileProps.PLANT_GROWTH, 9).prop(StaticTileProps.ALIVE, true));
+    }
+
+    public int getPriority() {
+        return -50;
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileCorn.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileCorn.java
@@ -1,11 +1,11 @@
 package de.ellpeck.rockbottom.world.tile;
 
 import de.ellpeck.rockbottom.api.render.tile.ITileRenderer;
-import de.ellpeck.rockbottom.api.tile.TilePlant;
+import de.ellpeck.rockbottom.api.tile.TileTallPlant;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
 import de.ellpeck.rockbottom.render.tile.TileCornRenderer;
 
-public class TileCorn extends TilePlant {
+public class TileCorn extends TileTallPlant {
 
     public TileCorn() {
         super(ResourceName.intern("corn"));

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileCorn.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileCorn.java
@@ -1,117 +1,18 @@
 package de.ellpeck.rockbottom.world.tile;
 
-import de.ellpeck.rockbottom.api.StaticTileProps;
-import de.ellpeck.rockbottom.api.entity.Entity;
-import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
-import de.ellpeck.rockbottom.api.item.ItemInstance;
 import de.ellpeck.rockbottom.api.render.tile.ITileRenderer;
-import de.ellpeck.rockbottom.api.tile.TileBasic;
-import de.ellpeck.rockbottom.api.tile.state.TileState;
-import de.ellpeck.rockbottom.api.util.BoundBox;
-import de.ellpeck.rockbottom.api.util.Util;
+import de.ellpeck.rockbottom.api.tile.TilePlant;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
-import de.ellpeck.rockbottom.api.world.IWorld;
-import de.ellpeck.rockbottom.api.world.layer.TileLayer;
 import de.ellpeck.rockbottom.render.tile.TileCornRenderer;
 
-import java.util.Collections;
-import java.util.List;
-
-public class TileCorn extends TileBasic {
+public class TileCorn extends TilePlant {
 
     public TileCorn() {
         super(ResourceName.intern("corn"));
-        this.addProps(StaticTileProps.TOP_HALF, StaticTileProps.CORN_GROWTH);
     }
 
     @Override
     protected ITileRenderer createRenderer(ResourceName name) {
         return new TileCornRenderer(name);
-    }
-
-    @Override
-    public boolean canStay(IWorld world, int x, int y, TileLayer layer, int changedX, int changedY, TileLayer changedLayer) {
-        return world.getState(layer, x, y).get(StaticTileProps.TOP_HALF) || this.canBeHere(world, x, y, layer);
-    }
-
-    @Override
-    public boolean canPlace(IWorld world, int x, int y, TileLayer layer, AbstractEntityPlayer player) {
-        return world.isPosLoaded(x, y - 1, false) && this.canBeHere(world, x, y, layer);
-    }
-
-    private boolean canBeHere(IWorld world, int x, int y, TileLayer layer) {
-        return world.getState(layer, x, y - 1).getTile().canKeepFarmablePlants(world, x, y, layer) && world.getState(TileLayer.LIQUIDS, x, y).getTile().isAir();
-    }
-
-    @Override
-    public boolean isFullTile() {
-        return false;
-    }
-
-    @Override
-    public BoundBox getBoundBox(IWorld world, TileState state, int x, int y, TileLayer layer) {
-        return null;
-    }
-
-    @Override
-    public void updateRandomly(IWorld world, int x, int y, TileLayer layer) {
-        if (Util.RANDOM.nextFloat() >= 0.95F) {
-            TileState state = world.getState(layer, x, y);
-            if (!state.get(StaticTileProps.TOP_HALF)) {
-                int growth = state.get(StaticTileProps.CORN_GROWTH);
-                if (growth < 9) {
-                    if (growth >= 3) {
-                        TileState above = world.getState(layer, x, y + 1);
-                        if (above.getTile() == this) {
-                            world.setState(layer, x, y + 1, above.prop(StaticTileProps.CORN_GROWTH, growth + 1));
-                        } else if (world.getState(layer, x, y + 1).getTile().canReplace(world, x, y + 1, layer)) {
-                            world.setState(layer, x, y + 1, this.getDefState().prop(StaticTileProps.TOP_HALF, true).prop(StaticTileProps.CORN_GROWTH, growth + 1));
-                        } else {
-                            return;
-                        }
-                    }
-                    world.setState(layer, x, y, state.prop(StaticTileProps.CORN_GROWTH, growth + 1));
-                }
-            }
-        }
-    }
-
-    @Override
-    public boolean onInteractWithBreakKey(IWorld world, int x, int y, TileLayer layer, double mouseX, double mouseY, AbstractEntityPlayer player) {
-        TileState state = world.getState(layer, x, y);
-        if (state.get(StaticTileProps.TOP_HALF) && state.get(StaticTileProps.CORN_GROWTH) >= 9) {
-            this.onDestroyed(world, x, y, player, layer, true);
-
-            if (!world.isClient()) {
-                world.setState(layer, x, y, state.prop(StaticTileProps.CORN_GROWTH, 5));
-                world.setState(layer, x, y - 1, world.getState(layer, x, y - 1).prop(StaticTileProps.CORN_GROWTH, 5));
-            }
-
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public List<ItemInstance> getDrops(IWorld world, int x, int y, TileLayer layer, Entity destroyer) {
-        TileState state = world.getState(layer, x, y);
-        if (state.get(StaticTileProps.TOP_HALF) && state.get(StaticTileProps.CORN_GROWTH) >= 9) {
-            return Collections.singletonList(new ItemInstance(this, Util.RANDOM.nextInt(3) + 1));
-        } else {
-            return Collections.emptyList();
-        }
-    }
-
-    @Override
-    public void doBreak(IWorld world, int x, int y, TileLayer layer, AbstractEntityPlayer breaker, boolean isRightTool, boolean allowDrop) {
-        if (!world.isClient()) {
-            boolean drop = allowDrop && (this.forceDrop || isRightTool);
-            boolean topHalf = world.getState(layer, x, y).get(StaticTileProps.TOP_HALF);
-            if (topHalf || world.getState(layer, x, y + 1).getTile() == this) {
-                world.destroyTile(x, y + (topHalf ? -1 : 1), layer, breaker, drop);
-            }
-            world.destroyTile(x, y, layer, breaker, drop);
-        }
     }
 }

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileCotton.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileCotton.java
@@ -1,0 +1,94 @@
+package de.ellpeck.rockbottom.world.tile;
+
+
+import de.ellpeck.rockbottom.api.GameContent;
+import de.ellpeck.rockbottom.api.StaticTileProps;
+import de.ellpeck.rockbottom.api.render.tile.ITileRenderer;
+import de.ellpeck.rockbottom.api.tile.TilePlant;
+import de.ellpeck.rockbottom.api.tile.state.TileState;
+import de.ellpeck.rockbottom.api.util.Util;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.api.world.IWorld;
+import de.ellpeck.rockbottom.api.world.layer.TileLayer;
+import de.ellpeck.rockbottom.render.tile.TileCottonRenderer;
+
+public class TileCotton extends TilePlant {
+    public TileCotton() {
+        super(ResourceName.intern("cotton"));
+        this.addProps(StaticTileProps.ALIVE);
+    }
+
+    @Override
+    protected final ITileRenderer createRenderer(ResourceName name) {
+        return new TileCottonRenderer(name);
+    }
+
+    @Override
+    public final void updateRandomly(IWorld world, int x, int y, TileLayer layer) {
+        TileState state = world.getState(layer, x, y);
+        if (!state.get(StaticTileProps.TOP_HALF)) {
+            int growth = state.get(StaticTileProps.PLANT_GROWTH);
+
+            boolean left = true;
+            TileState liquid = world.getState(TileLayer.LIQUIDS, x - 1, y - 1);
+            if (liquid.getTile() != GameContent.TILE_WATER) {
+                left = false;
+                liquid = world.getState(TileLayer.LIQUIDS, x + 1, y - 1);
+            }
+
+            boolean wasAlive = state.get(StaticTileProps.ALIVE);
+            boolean alive = liquid.getTile() == GameContent.TILE_WATER && world.getCombinedLight(x, y) > 50;
+            if (wasAlive != alive) {
+                if (alive) {
+                    world.setState(layer, x, y, state.prop(StaticTileProps.ALIVE, true));
+                    if (growth >= 4) {
+                        TileState up = world.getState(layer, x, y + 1);
+                        if (up.getTile() == this) {
+                            world.setState(layer, x, y + 1, up.prop(StaticTileProps.ALIVE, true));
+                        }
+                    }
+                } else {
+                    world.setState(layer, x, y, state.prop(StaticTileProps.ALIVE, false));
+                    if (growth >= 4) {
+                        TileState up = world.getState(layer, x, y + 1);
+                        if (up.getTile() == this) {
+                            world.setState(layer, x, y + 1, up.prop(StaticTileProps.ALIVE, false));
+                        }
+                    }
+                }
+            }
+
+            if (Util.RANDOM.nextFloat() >= 0.95F && growth < 9) {
+                if (alive) {
+                    if (growth >= 3) {
+                        TileState topHalf;
+                        if ((topHalf = world.getState(layer, x, y + 1)).getTile() == this) {
+                            world.setState(layer, x, y + 1, topHalf.prop(StaticTileProps.PLANT_GROWTH, growth + 1).prop(StaticTileProps.ALIVE, true));
+                        } else {
+                            if (!world.getState(layer, x, y + 1).getTile().canReplace(world, x, y + 1, layer)) {
+                                return;
+                            }
+
+                            world.setState(layer, x, y + 1, this.getDefState().prop(StaticTileProps.TOP_HALF, Boolean.TRUE).prop(StaticTileProps.PLANT_GROWTH, growth + 1).prop(StaticTileProps.ALIVE, true));
+                        }
+                    }
+                    if (Util.RANDOM.nextFloat() >= 0.6f) {
+                        int level = liquid.get(GameContent.TILE_WATER.level);
+                        if (level > 0) {
+                            world.setState(TileLayer.LIQUIDS, x + (left ? -1 : 1), y - 1, liquid.prop(GameContent.TILE_WATER.level, level - 1));
+                        } else {
+                            world.setState(TileLayer.LIQUIDS, x + (left ? -1 : 1), y - 1, GameContent.TILE_AIR.getDefState());
+                        }
+                    }
+                    world.setState(layer, x, y, state.prop(StaticTileProps.PLANT_GROWTH, growth + 1).prop(StaticTileProps.ALIVE, true));
+                } else {
+                    world.setState(layer, x, y, state.prop(StaticTileProps.ALIVE, false));
+                    if (growth >= 3) {
+                        world.setState(layer, x, y + 1, this.getDefState().prop(StaticTileProps.TOP_HALF, Boolean.TRUE).prop(StaticTileProps.PLANT_GROWTH, growth).prop(StaticTileProps.ALIVE, false));
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileCotton.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileCotton.java
@@ -4,7 +4,7 @@ package de.ellpeck.rockbottom.world.tile;
 import de.ellpeck.rockbottom.api.GameContent;
 import de.ellpeck.rockbottom.api.StaticTileProps;
 import de.ellpeck.rockbottom.api.render.tile.ITileRenderer;
-import de.ellpeck.rockbottom.api.tile.TilePlant;
+import de.ellpeck.rockbottom.api.tile.TileTallPlant;
 import de.ellpeck.rockbottom.api.tile.state.TileState;
 import de.ellpeck.rockbottom.api.util.Util;
 import de.ellpeck.rockbottom.api.util.reg.ResourceName;
@@ -12,7 +12,7 @@ import de.ellpeck.rockbottom.api.world.IWorld;
 import de.ellpeck.rockbottom.api.world.layer.TileLayer;
 import de.ellpeck.rockbottom.render.tile.TileCottonRenderer;
 
-public class TileCotton extends TilePlant {
+public class TileCotton extends TileTallPlant {
     public TileCotton() {
         super(ResourceName.intern("cotton"));
         this.addProps(StaticTileProps.ALIVE);

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/TileSpinningWheel.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/TileSpinningWheel.java
@@ -1,0 +1,112 @@
+package de.ellpeck.rockbottom.world.tile;
+
+
+import de.ellpeck.rockbottom.api.GameContent;
+import de.ellpeck.rockbottom.api.StaticTileProps;
+import de.ellpeck.rockbottom.api.entity.AbstractEntityItem;
+import de.ellpeck.rockbottom.api.entity.player.AbstractEntityPlayer;
+import de.ellpeck.rockbottom.api.item.ItemInstance;
+import de.ellpeck.rockbottom.api.render.tile.ITileRenderer;
+import de.ellpeck.rockbottom.api.tile.MultiTile;
+import de.ellpeck.rockbottom.api.tile.state.TileState;
+import de.ellpeck.rockbottom.api.util.BoundBox;
+import de.ellpeck.rockbottom.api.util.Pos2;
+import de.ellpeck.rockbottom.api.util.Util;
+import de.ellpeck.rockbottom.api.util.reg.ResourceName;
+import de.ellpeck.rockbottom.api.world.IWorld;
+import de.ellpeck.rockbottom.api.world.layer.TileLayer;
+import de.ellpeck.rockbottom.render.tile.TileSpinningWheelRenderer;
+
+public class TileSpinningWheel extends MultiTile {
+    public TileSpinningWheel() {
+        super(ResourceName.intern("spinning_wheel"));
+        this.addProps(StaticTileProps.SPINNING_STAGE);
+    }
+
+    @Override
+    protected boolean[][] makeStructure() {
+        return new boolean[][]{
+                {true, true, true},
+                {true, true, true},
+                {true, true, true}
+        };
+    }
+
+    @Override
+    public TileState getPlacementState(IWorld world, int x, int y, TileLayer layer, ItemInstance instance, AbstractEntityPlayer placer) {
+        return getDefState().prop(StaticTileProps.SPINNING_STAGE, 0);
+    }
+
+    @Override
+    public boolean isFullTile() {
+        return false;
+    }
+
+    @Override
+    public BoundBox getBoundBox(IWorld world, TileState state, int x, int y, TileLayer layer) {
+        return null;
+    }
+
+    @Override
+    public int getWidth() {
+        return 3;
+    }
+
+    @Override
+    public int getHeight() {
+        return 3;
+    }
+
+    @Override
+    public int getMainX() {
+        return 0;
+    }
+
+    @Override
+    public int getMainY() {
+        return 0;
+    }
+
+    @Override
+    public boolean onInteractWith(IWorld world, int x, int y, TileLayer layer, double mouseX, double mouseY, AbstractEntityPlayer player) {
+        Pos2 main = this.getMainPos(x, y, world.getState(layer, x, y));
+        TileState state = world.getState(layer, main.getX(), main.getY());
+
+        if (state.getTile() instanceof TileSpinningWheel) {
+            int stage = state.get(StaticTileProps.SPINNING_STAGE);
+
+            if (stage == 0) {
+                ItemInstance held = player.getInv().get(player.getSelectedSlot());
+                if (held != null && held.getItem() == GameContent.TILE_COTTON.getItem() && held.getAmount() >= 3) {
+                    if (!world.isClient()) {
+                        player.getInv().remove(player.getSelectedSlot(), 3);
+                        world.setState(layer, main.getX(), main.getY(), state.prop(StaticTileProps.SPINNING_STAGE, 1));
+                    }
+                    return true;
+                }
+            } else {
+                if (!world.isClient()) {
+                    if (stage < 7) {
+                        world.setState(layer, main.getX(), main.getY(), state.prop(StaticTileProps.SPINNING_STAGE, stage + 1));
+                    } else {
+                        world.setState(layer, main.getX(), main.getY(), state.prop(StaticTileProps.SPINNING_STAGE, 0));
+                        AbstractEntityItem.spawn(world, new ItemInstance(GameContent.ITEM_YARN), main.getX() + 2.5, main.getY() + 1.5, Util.RANDOM.nextGaussian() * 0.1, Util.RANDOM.nextGaussian() * 0.1);
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canPlaceInLayer(TileLayer layer) {
+        return layer == TileLayer.MAIN;
+    }
+
+    @Override
+    protected ITileRenderer<TileSpinningWheel> createRenderer(ResourceName name) {
+        return new TileSpinningWheelRenderer(name, this);
+    }
+
+}


### PR DESCRIPTION
Cotton generates in the world, but it must be next to a water source or it withers and dies. Cotton consumes water from adjacent tiles when growing, and yields 1-3 cotton items when harvested like corn. Since there are now multiple plants with many shared behaviours, I added a `TilePlant` to the API so that mods can easily add their own plants as well.

You can see three cotton plants below. The one on the left is fully grown, the one in the middle has withered due to a lack of water, and the right one is partially grown.

![Cotton](https://i.imgur.com/MWiginb.png)

The Spinning Wheel is used to convert Cotton into Yarn by right-clicking several times. It plays [a nice spinning animation](https://imgur.com/a/kGLe0Os) while you do this (the current textures are only temporary until Wiiv is able to work on some better ones). In the future, yarn can be used to create clothes and other fabric items.

Also check the [API](https://github.com/RockBottomGame/API/pull/37) and [Assets](https://github.com/RockBottomGame/Assets/pull/24) PR's.