### PR TITLE
Replace int based movement types with Enum for better readability. Al…

### DIFF
--- a/src/main/java/de/ellpeck/rockbottom/world/entity/player/InteractionManager.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/entity/player/InteractionManager.java
@@ -5,6 +5,7 @@ import de.ellpeck.rockbottom.api.data.settings.Settings;
 import de.ellpeck.rockbottom.api.entity.Entity;
 import de.ellpeck.rockbottom.api.entity.player.AbstractPlayerEntity;
 import de.ellpeck.rockbottom.api.entity.player.IInteractionManager;
+import de.ellpeck.rockbottom.api.entity.player.MoveType;
 import de.ellpeck.rockbottom.api.entity.player.statistics.ItemStatistic;
 import de.ellpeck.rockbottom.api.event.EventResult;
 import de.ellpeck.rockbottom.api.event.impl.*;
@@ -268,27 +269,27 @@ public class InteractionManager implements IInteractionManager {
                 }
 
                 if (Settings.KEY_LEFT.isDown()) {
-                    player.move(0);
+                    player.move(MoveType.LEFT);
                 } else if (Settings.KEY_RIGHT.isDown()) {
-                    player.move(1);
+                    player.move(MoveType.RIGHT);
                 }
 
                 if (Settings.KEY_UP.isDown()) {
                     if (Settings.KEY_JUMP.isPressed() && player.getGameMode().isCreative()) {
                         player.isFlying = true;
                     } else {
-                        player.move(3);
+                        player.move(MoveType.UP);
                     }
                 } else if (Settings.KEY_DOWN.isDown()) {
                     if (Settings.KEY_JUMP.isPressed() && player.getGameMode().isCreative()) {
                         player.isFlying = false;
                     } else {
-                        player.move(4);
+                        player.move(MoveType.DOWN);
                     }
                 }
 
                 if (Settings.KEY_JUMP.isDown()) {
-                    player.move(2);
+                    player.move(MoveType.JUMP);
                 }
 
                 // If the player is in camera mode, they cannot do any interaction such as breaking or attacking

--- a/src/main/java/de/ellpeck/rockbottom/world/entity/player/PlayerEntity.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/entity/player/PlayerEntity.java
@@ -10,6 +10,7 @@ import de.ellpeck.rockbottom.api.entity.Entity;
 import de.ellpeck.rockbottom.api.entity.player.AbstractPlayerEntity;
 import de.ellpeck.rockbottom.api.entity.player.CameraMode;
 import de.ellpeck.rockbottom.api.entity.player.GameMode;
+import de.ellpeck.rockbottom.api.entity.player.MoveType;
 import de.ellpeck.rockbottom.api.entity.player.knowledge.IKnowledgeManager;
 import de.ellpeck.rockbottom.api.entity.player.statistics.IStatistics;
 import de.ellpeck.rockbottom.api.entity.player.statistics.NumberStatistic;
@@ -726,52 +727,55 @@ public class PlayerEntity extends AbstractPlayerEntity {
     }
 
     @Override
-    public boolean move(int type) {
+    public boolean move(MoveType type) {
         if (this.getCameraMode().isActive()) {
             return this.getCameraMode().move(type);
         }
 
-        if (type == 0) {    // Move left
-            this.motionX -= this.getMoveSpeed();
-            this.facing = Direction.LEFT;
-            return true;
-        } else if (type == 1) { // Move right
-            this.motionX += this.getMoveSpeed();
-            this.facing = Direction.RIGHT;
-            return true;
-        } else if (type == 2) { // Jump
-            if (this.canSwim) {
-                this.motionY = 0.075;
-            } else if(this.isFlying) {
-                //this.motionY += this.getMoveSpeed();
-                //this.facing = Direction.UP;
-                //return true;
-            } else {
-                this.jump(this.getJumpHeight());
-            }
-            return true;
-        } else if (type == 3) { // Move up
-            if (this.canClimb) {
-                this.motionY += this.getClimbSpeed();
-                this.facing = Direction.UP;
-                return true;
-            } else if (this.isFlying) {
-                this.motionY += this.getMoveSpeed();
-                this.facing = Direction.UP;
+        switch (type){
+            case LEFT: {
+                this.motionX -= this.getMoveSpeed();
+                this.facing = Direction.LEFT;
                 return true;
             }
-        } else if (type == 4) { // Move down
-            this.isDropping = true;
-            if (this.canClimb) {
-                this.motionY -= this.getClimbSpeed();
-                this.facing = Direction.DOWN;
-                return true;
-            } else if (this.isFlying) {
-                this.motionY -= this.getMoveSpeed();
-                this.facing = Direction.DOWN;
+            case RIGHT: {
+                this.motionX += this.getMoveSpeed();
+                this.facing = Direction.RIGHT;
                 return true;
             }
-
+            case JUMP: {
+                if (this.canSwim) {
+                    this.motionY = 0.075;
+                } else if(this.isFlying) {
+                    //this.motionY += this.getMoveSpeed();
+                    //this.facing = Direction.UP;
+                    //return true;
+                } else {
+                    this.jump(this.getJumpHeight());
+                }
+                return true;
+            }
+            case UP: {
+                if (this.canClimb) {
+                    this.motionY += this.getClimbSpeed();
+                    this.facing = Direction.UP;
+                } else if (this.isFlying) {
+                    this.motionY += this.getMoveSpeed();
+                    this.facing = Direction.UP;
+                }
+                return true;
+            }
+            case DOWN: {
+                this.isDropping = true;
+                if (this.canClimb) {
+                    this.motionY -= this.getClimbSpeed();
+                    this.facing = Direction.DOWN;
+                } else if (this.isFlying) {
+                    this.motionY -= this.getMoveSpeed();
+                    this.facing = Direction.DOWN;
+                }
+                return true;
+            }
         }
         return false;
     }

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/LadderTile.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/LadderTile.java
@@ -24,7 +24,7 @@ public class LadderTile extends BasicTile {
 
     @Override
     public boolean canClimb(IWorld world, int x, int y, TileLayer layer, TileState state, BoundingBox entityBox, BoundingBox entityBoxMotion, List<BoundingBox> tileBoxes, Entity entity) {
-        return Util.floor(entity.getY()) == y;
+        return Util.floor(entity.getY()) == y && Util.floor(entity.getX()) == x;
     }
 
     @Override

--- a/src/main/java/de/ellpeck/rockbottom/world/tile/RopeTile.java
+++ b/src/main/java/de/ellpeck/rockbottom/world/tile/RopeTile.java
@@ -28,7 +28,7 @@ public class RopeTile extends BasicTile {
 
     @Override
     public boolean canClimb(IWorld world, int x, int y, TileLayer layer, TileState state, BoundingBox entityBox, BoundingBox entityBoxMotion, List<BoundingBox> tileBoxes, Entity entity) {
-        return Util.floor(entity.getY()) == y;
+        return Util.floor(entity.getY()) == y && entity.getX() >= (x + 0.25F) && entity.getX() <= (x + 0.75F);
     }
 
     @Override


### PR DESCRIPTION
…so changed if-else based statements to switch-case.
Also fix the clmbing bug

Trello: https://trello.com/c/TqKn3Thq/19-add-movetype-enum-for-easier-readability-in-the-move-method-instead-of-int
and
Trello: https://trello.com/c/25mklZfR/26-you-can-climb-without-actually-being-in-the-proper-tile